### PR TITLE
fix: correct Vite dev proxy port from 8001 to 8000

### DIFF
--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -17,8 +17,8 @@ export default defineConfig({
   server: {
     port: 5173,
     proxy: {
-      '/api': 'http://localhost:8001',
-      '/ws': { target: 'ws://localhost:8001', ws: true },
+      '/api': 'http://localhost:8000',
+      '/ws': { target: 'ws://localhost:8000', ws: true },
     },
   },
 })


### PR DESCRIPTION
Backend runs on :8000 (matches Docker config). The wrong port caused all API calls and WebSocket connections to fail in the dev server, showing the "Reconnecting…" banner immediately on load.