### PR TITLE
ci: add Claude automated code review GitHub Action

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -20,6 +20,7 @@ jobs:
       contents: read
       pull-requests: write
       issues: write
+      id-token: write
     steps:
       - uses: anthropics/claude-code-action@v1
         with:


### PR DESCRIPTION
Triggers on PR open/update for automatic /review, and responds to @claude mentions in PR comments for interactive feedback. Uses claude-sonnet-4-6 with project-specific system prompt.

Requires ANTHROPIC_API_KEY secret in repo settings.