### PR TITLE
fix: attachment upload — unwrap axios response, proxy /uploads/ in dev

### DIFF
--- a/frontend/src/components/Chat/GifPicker.jsx
+++ b/frontend/src/components/Chat/GifPicker.jsx
@@ -56,7 +56,7 @@ export default function GifPicker({ onSelect, onClose }) {
   return (
     <div
       ref={containerRef}
-      className="absolute bottom-full left-0 mb-2 w-80 bg-[var(--bg)] border border-[var(--border-glow)] rounded shadow-[0_0_16px_rgba(0,206,209,0.25)] z-20"
+      className="absolute bottom-full left-0 mb-2 w-80 bg-[var(--bg-primary)] border border-[var(--border-glow)] rounded shadow-[0_0_16px_rgba(0,206,209,0.25)] z-20"
       data-testid="gif-picker"
     >
       {/* Search input */}

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -18,6 +18,7 @@ export default defineConfig({
     port: 5173,
     proxy: {
       '/api': 'http://localhost:8100',
+      '/uploads': 'http://localhost:8100',
       '/ws': { target: 'ws://localhost:8100', ws: true },
     },
   },


### PR DESCRIPTION
Two bugs introduced with the Phase 2 attachment feature:

1. MessageInput called finalizeAttachment(tempId, axiosResponse) instead of finalizeAttachment(tempId, axiosResponse.data), so attachment id and url were never stored in the pending-attachment state. The send button stayed disabled because readyIds was always empty, making it impossible to send a file without also typing text.

2. Vite dev proxy didn't forward /uploads/* to the backend, so images loaded from /uploads/<uuid>.png returned 404 and never displayed.