### PR TITLE
fix: switch Tenor calls to httpx, fix media_filter, remove invalid AP…

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -12,3 +12,7 @@ CORS_ORIGINS=["http://localhost:3000","http://localhost:5173"]
 # App
 DEBUG=False
 LOG_LEVEL=INFO
+
+# Tenor GIF API v2 — get a key at console.cloud.google.com → APIs & Services → Credentials
+# Enable "Tenor API" on your project first, then create an API key.
+TENOR_API_KEY=your-tenor-api-key-here

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -11,8 +11,8 @@ class Settings(BaseSettings):
     DEBUG: bool = False
     LOG_LEVEL: str = "INFO"
 
-    # Tenor GIF API (v2)
-    TENOR_API_KEY: str = "AIzaSyAyimkuYQYF_FXVALexPuGQctUWRURdCyk"
+    # Tenor GIF API (v2) — set in .env (console.cloud.google.com → enable Tenor API → create key)
+    TENOR_API_KEY: str = ""
     TENOR_API_BASE: str = "https://tenor.googleapis.com/v2"
     TENOR_SEARCH_LIMIT: int = 20
 

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -9,3 +9,4 @@ pydantic[email]==2.10.4
 pydantic-settings==2.7.0
 python-multipart==0.0.20
 Pillow==11.1.0
+httpx==0.28.1


### PR DESCRIPTION
…I key

- Replace urllib with httpx in gifs.py — urllib had no SSL cert bundle on Windows, causing every Tenor API call to fail with a certificate error
- Fix media_filter param: was "gif" (only returns full gif format) but _parse_results looks for tinygif/nanogif, so all results were silently dropped; now requests "tinygif,nanogif" to match the parser
- Add gif-format fallback in _parse_results for resilience
- Remove hardcoded invalid TENOR_API_KEY default from config.py; add setup instructions to .env.example
- Update test_gifs.py mocks from urllib to httpx fake client
- Add httpx==0.28.1 to requirements.txt