### PR TITLE
fix: add frontend healthcheck so Caddy waits for nginx to be ready

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -52,6 +52,12 @@ services:
     depends_on:
       backend:
         condition: service_healthy
+    healthcheck:
+      test: ["CMD-SHELL", "wget -qO- http://localhost/ || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 3
+      start_period: 10s
     restart: unless-stopped
 
 volumes:


### PR DESCRIPTION
Without a healthcheck the frontend was never marked healthy, causing Caddy (which depends on service_healthy) to wait indefinitely. Uses wget since the nginx image ships it; start_period gives nginx time to settle before failures count against retries.