### PR TITLE
fix: call audio.play() explicitly for WebRTC remote streams

### DIFF
--- a/frontend/src/hooks/useVoiceChat.js
+++ b/frontend/src/hooks/useVoiceChat.js
@@ -54,6 +54,7 @@ export function useVoiceChat(channelId, currentUser, sendMsg) {
       const existing = document.querySelector(`audio[data-peer-id="${remoteUserId}"]`)
       if (existing) {
         existing.srcObject = ev.streams[0]
+        existing.play().catch((err) => console.warn('useVoiceChat: audio resume blocked', err))
         return
       }
       const audio = document.createElement('audio')
@@ -61,6 +62,9 @@ export function useVoiceChat(channelId, currentUser, sendMsg) {
       audio.autoplay = true
       audio.setAttribute('data-peer-id', String(remoteUserId))
       document.body.appendChild(audio)
+      // autoplay attribute alone is not reliable for MediaStream sources —
+      // explicit play() is required by most browsers.
+      audio.play().catch((err) => console.warn('useVoiceChat: audio play blocked', err))
     }
 
     pc.onconnectionstatechange = () => {


### PR DESCRIPTION
The ontrack handler created audio elements with the autoplay attribute but never called .play(). For MediaStream-backed srcObject elements, browsers require an explicit play() call — autoplay alone is not reliable and was silently failing, so remote peers could transmit but no one could hear the audio.