### PR TITLE
feat: show voice participant count in channel sidebar

### DIFF
--- a/backend/app/schemas/channel.py
+++ b/backend/app/schemas/channel.py
@@ -29,5 +29,6 @@ class ChannelResponse(ChannelBase):
     creator: UserResponse
 
     unread_count: int = 0
+    voice_count: int = 0
 
     model_config = {"from_attributes": True}

--- a/frontend/src/components/Chat/ChannelList.jsx
+++ b/frontend/src/components/Chat/ChannelList.jsx
@@ -65,6 +65,11 @@ export default function ChannelList({ onNavigate }) {
                 >
                   <span className="text-[var(--text-muted)]">#</span>
                   <span className="truncate flex-1">{ch.name}</span>
+                  {ch.voice_count > 0 && (
+                    <span className="text-xs font-mono text-[var(--accent-teal)] shrink-0 flex items-center gap-0.5">
+                      🎤{ch.voice_count}
+                    </span>
+                  )}
                   {!isActive && unread > 0 && (
                     <span className="ml-auto text-xs font-bold px-1.5 py-0.5 rounded-full
                                      bg-[var(--crt-orange)] text-[var(--crt-dark)] shrink-0">

--- a/frontend/src/store/chatStore.js
+++ b/frontend/src/store/chatStore.js
@@ -139,6 +139,23 @@ const useChatStore = create((set, get) => ({
 
   clearPendingAttachments: () => set({ pendingAttachments: [] }),
 
+  /* ── Voice counts (per-channel, for sidebar indicator) ───────── */
+  // Absolute set — used when we receive a voice.state_snapshot
+  setChannelVoiceCount: (channelId, count) =>
+    set((s) => ({
+      channels: s.channels.map((c) =>
+        c.id === channelId ? { ...c, voice_count: Math.max(0, count) } : c
+      ),
+    })),
+
+  // Delta update — used on voice.user_joined (+1) / voice.user_left (-1)
+  adjustChannelVoiceCount: (channelId, delta) =>
+    set((s) => ({
+      channels: s.channels.map((c) =>
+        c.id === channelId ? { ...c, voice_count: Math.max(0, (c.voice_count ?? 0) + delta) } : c
+      ),
+    })),
+
   /* ── Reply ────────────────────────────────────────────────────── */
   setReplyingTo: (message) => set({ replyingTo: message }),
   clearReplyingTo: () => set({ replyingTo: null }),


### PR DESCRIPTION
- ChannelResponse gains voice_count populated via Redis batch query in list_channels
- chatStore adds setChannelVoiceCount (snapshot) and adjustChannelVoiceCount (delta)
- useWebSocket updates voice counts on state_snapshot, user_joined, user_left
- ChannelList renders a 🎤N badge next to any channel with active voice users