### PR TITLE
feat: favicon badge + tab title for unread messages

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>chisme</title>
+    <link rel="icon" href="data:," />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;700&display=swap" rel="stylesheet" />

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -9,8 +9,10 @@ import DMView from './components/Chat/DMView'
 import MessageSearch from './components/Common/MessageSearch'
 import ShortcutsModal from './components/Common/ShortcutsModal'
 import ErrorBoundary from './components/Common/ErrorBoundary'
+import { useFaviconBadge } from './hooks/useFaviconBadge'
 
 function ChatLayout() {
+  useFaviconBadge()
   const fetchChannels = useChatStore((s) => s.fetchChannels)
   const activeDmId = useDMStore((s) => s.activeDmId)
   const [searchOpen, setSearchOpen] = useState(false)

--- a/frontend/src/hooks/useFaviconBadge.js
+++ b/frontend/src/hooks/useFaviconBadge.js
@@ -1,0 +1,20 @@
+import { useEffect } from 'react'
+import useChatStore from '../store/chatStore'
+import { setFaviconBadge } from '../utils/favicon'
+
+/**
+ * Watches the total unread message count across all channels and:
+ *  - Updates the favicon with an orange badge showing the count
+ *  - Prepends "(N)" to the document title when there are unread messages
+ *
+ * Should be called once inside ChatLayout.
+ */
+export function useFaviconBadge() {
+  const unreadCounts = useChatStore((s) => s.unreadCounts)
+
+  useEffect(() => {
+    const total = Object.values(unreadCounts).reduce((sum, n) => sum + n, 0)
+    setFaviconBadge(total)
+    document.title = total > 0 ? `(${total > 99 ? '99+' : total}) chisme` : 'chisme'
+  }, [unreadCounts])
+}

--- a/frontend/src/utils/favicon.js
+++ b/frontend/src/utils/favicon.js
@@ -1,0 +1,73 @@
+/**
+ * Dynamic favicon badge utility.
+ *
+ * Draws a 32×32 canvas favicon: dark background, CRT-teal "C" lettermark,
+ * and an optional orange badge in the top-right corner showing the unread count.
+ *
+ * Usage:
+ *   setFaviconBadge(0)   // plain icon, no badge
+ *   setFaviconBadge(5)   // icon + "5" badge
+ *   setFaviconBadge(100) // icon + "!" badge (overflow)
+ */
+
+let _link = null
+
+function getFaviconLink() {
+  if (!_link) {
+    _link = document.querySelector("link[rel~='icon']")
+    if (!_link) {
+      _link = document.createElement('link')
+      _link.rel = 'icon'
+      _link.type = 'image/png'
+      document.head.appendChild(_link)
+    }
+  }
+  return _link
+}
+
+function drawFavicon(count) {
+  const size = 32
+  const canvas = document.createElement('canvas')
+  canvas.width = size
+  canvas.height = size
+  const ctx = canvas.getContext('2d')
+
+  // Dark CRT background with rounded corners
+  ctx.fillStyle = '#0a0a0f'
+  ctx.beginPath()
+  ctx.roundRect(0, 0, size, size, 6)
+  ctx.fill()
+
+  // "C" lettermark in CRT teal
+  ctx.fillStyle = '#00ced1'
+  ctx.font = 'bold 20px "Courier New", monospace'
+  ctx.textAlign = 'center'
+  ctx.textBaseline = 'middle'
+  ctx.fillText('C', size / 2, size / 2 + 1)
+
+  if (count > 0) {
+    // Orange badge circle in top-right
+    const r = 9
+    const bx = size - r + 1
+    const by = r - 1
+
+    ctx.fillStyle = '#ff8c42'
+    ctx.beginPath()
+    ctx.arc(bx, by, r, 0, Math.PI * 2)
+    ctx.fill()
+
+    // Count label — "!" when > 99
+    const label = count > 99 ? '!' : String(count)
+    ctx.fillStyle = '#0a0a0f'
+    ctx.font = `bold ${label.length > 1 ? 8 : 10}px "Courier New", monospace`
+    ctx.textAlign = 'center'
+    ctx.textBaseline = 'middle'
+    ctx.fillText(label, bx, by)
+  }
+
+  return canvas.toDataURL('image/png')
+}
+
+export function setFaviconBadge(count) {
+  getFaviconLink().href = drawFavicon(count)
+}


### PR DESCRIPTION
- favicon.js draws a 32px canvas icon (dark bg, teal "C") with an optional orange badge in the top-right showing the unread count (or "!" over 99)
- useFaviconBadge hook sums all unreadCounts and updates both the favicon and document title ("(N) chisme") whenever the total changes
- index.html adds a data:, placeholder icon to suppress the 404 on /favicon.ico before React mounts and the canvas icon takes over