### PR TITLE
fix: mobile back button always visible while scrolling

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -44,7 +44,7 @@ function ChatLayout() {
 
   return (
     <ErrorBoundary>
-      <div className="flex h-screen overflow-hidden bg-[var(--bg-primary)]">
+      <div className="flex overflow-hidden bg-[var(--bg-primary)]" style={{ height: '100dvh' }}>
         <Sidebar
           onSearchOpen={() => setSearchOpen(true)}
           onNavigate={handleNavigate}

--- a/frontend/src/components/Chat/DMView.jsx
+++ b/frontend/src/components/Chat/DMView.jsx
@@ -93,7 +93,7 @@ export default function DMView({ onBack }) {
   return (
     <div className="flex-1 flex flex-col min-w-0 min-h-0" data-testid="dm-view">
       {/* DM header */}
-      <div className="px-4 py-3 border-b border-[var(--border)] flex items-center gap-2 flex-shrink-0">
+      <div className="sticky top-0 z-10 px-4 py-3 border-b border-[var(--border)] bg-[var(--bg-primary)] flex items-center gap-2 flex-shrink-0">
         <button
           onClick={onBack}
           className="md:hidden text-[var(--text-muted)] hover:text-[var(--text-primary)] text-lg transition-colors flex-shrink-0"

--- a/frontend/src/components/Layout/Header.jsx
+++ b/frontend/src/components/Layout/Header.jsx
@@ -7,7 +7,7 @@ export default function Header({ onBack }) {
   if (!channel) return null
 
   return (
-    <header className="px-6 py-4 border-b border-[var(--border)] bg-black/20 flex items-center gap-3 flex-shrink-0">
+    <header className="sticky top-0 z-10 px-6 py-4 border-b border-[var(--border)] bg-[var(--bg-primary)] flex items-center gap-3 flex-shrink-0">
       <button
         onClick={onBack}
         className="md:hidden text-[var(--text-muted)] hover:text-[var(--text-primary)] text-lg transition-colors flex-shrink-0"


### PR DESCRIPTION
- Use 100dvh instead of h-screen so iOS Safari reports the correct viewport height and doesn't let the document-level scroll escape
- Add sticky top-0 z-10 to channel Header and DM header bar so the back arrow stays pinned even if layout constraints break on mobile
- Give both headers a solid bg-[var(--bg-primary)] so scrolled content doesn't bleed through underneath