### PR TITLE
fix: persistent PWA sessions via refresh tokens (#34)

### DIFF
--- a/backend/alembic/versions/013_add_refresh_tokens.py
+++ b/backend/alembic/versions/013_add_refresh_tokens.py
@@ -1,0 +1,47 @@
+"""add refresh_tokens table
+
+Revision ID: 013_add_refresh_tokens
+Revises: 012_phase5_logical_servers
+Create Date: 2026-02-24
+
+Introduces:
+- refresh_tokens table for persistent PWA sessions
+  Columns: id, user_id (FK→users CASCADE), token (unique), expires_at, revoked, created_at
+"""
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision = "013_add_refresh_tokens"
+down_revision = "012_phase5_logical_servers"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "refresh_tokens",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column(
+            "user_id",
+            sa.Integer(),
+            sa.ForeignKey("users.id", ondelete="CASCADE"),
+            nullable=False,
+            index=True,
+        ),
+        sa.Column("token", sa.String(128), unique=True, nullable=False),
+        sa.Column("expires_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("revoked", sa.Boolean(), nullable=False, server_default=sa.false()),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+        ),
+    )
+    op.create_index("ix_refresh_tokens_token", "refresh_tokens", ["token"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_refresh_tokens_token", table_name="refresh_tokens")
+    op.drop_table("refresh_tokens")

--- a/backend/app/api/auth.py
+++ b/backend/app/api/auth.py
@@ -10,7 +10,7 @@ from app.models.channel import Channel
 from app.models.server import Server
 from app.models.server_membership import ROLE_MEMBER, ROLE_OWNER, ServerMembership
 from app.models.user import User
-from app.schemas.token import Token
+from app.schemas.token import RefreshRequest, RefreshResponse, Token
 from app.schemas.user import UserCreate, UserLogin, UserResponse
 from app.services import auth_service
 
@@ -109,8 +109,10 @@ async def register(user_in: UserCreate, db: Session = Depends(get_db)) -> Token:
         user,
         expires_delta=timedelta(minutes=settings.ACCESS_TOKEN_EXPIRE_MINUTES),
     )
+    refresh_token = auth_service.create_refresh_token(user, db)
     return Token(
         access_token=access_token,
+        refresh_token=refresh_token,
         token_type="bearer",
         user=UserResponse.model_validate(user),
     )
@@ -133,11 +135,34 @@ async def login(credentials: UserLogin, db: Session = Depends(get_db)) -> Token:
         user,
         expires_delta=timedelta(minutes=settings.ACCESS_TOKEN_EXPIRE_MINUTES),
     )
+    refresh_token = auth_service.create_refresh_token(user, db)
     return Token(
         access_token=access_token,
+        refresh_token=refresh_token,
         token_type="bearer",
         user=UserResponse.model_validate(user),
     )
+
+
+@router.post("/refresh", response_model=RefreshResponse)
+async def refresh(body: RefreshRequest, db: Session = Depends(get_db)) -> RefreshResponse:
+    user = auth_service.validate_refresh_token(body.refresh_token, db)
+    if not user:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid or expired refresh token")
+    # Rotate: revoke old token, issue new pair
+    auth_service.revoke_refresh_token(body.refresh_token, db)
+    access_token = auth_service.create_access_token(
+        user,
+        expires_delta=timedelta(minutes=settings.ACCESS_TOKEN_EXPIRE_MINUTES),
+    )
+    new_refresh = auth_service.create_refresh_token(user, db)
+    return RefreshResponse(access_token=access_token, refresh_token=new_refresh)
+
+
+@router.post("/logout")
+async def logout(body: RefreshRequest, db: Session = Depends(get_db)) -> dict:
+    auth_service.revoke_refresh_token(body.refresh_token, db)
+    return {"ok": True}
 
 
 @router.get("/me", response_model=UserResponse)

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -6,6 +6,7 @@ class Settings(BaseSettings):
     SECRET_KEY: str
     ALGORITHM: str = "HS256"
     ACCESS_TOKEN_EXPIRE_MINUTES: int = 30
+    REFRESH_TOKEN_EXPIRE_DAYS: int = 30
     CORS_ORIGINS: list[str] = ["http://localhost:3000", "http://localhost:5173"]
     DEBUG: bool = False
     LOG_LEVEL: str = "INFO"

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -4,6 +4,7 @@ from app.models.dm_channel import DirectMessageChannel as DirectMessageChannel
 from app.models.message import Message as Message
 from app.models.reaction import Reaction as Reaction
 from app.models.read_receipt import ReadReceipt as ReadReceipt
+from app.models.refresh_token import RefreshToken as RefreshToken
 from app.models.server import Server as Server
 from app.models.server_invite import ServerInvite as ServerInvite
 from app.models.server_membership import ServerMembership as ServerMembership

--- a/backend/app/models/refresh_token.py
+++ b/backend/app/models/refresh_token.py
@@ -1,0 +1,18 @@
+from sqlalchemy import Boolean, Column, DateTime, ForeignKey, Integer, String
+from sqlalchemy.orm import relationship
+from sqlalchemy.sql import func
+
+from app.database import Base
+
+
+class RefreshToken(Base):
+    __tablename__ = "refresh_tokens"
+
+    id = Column(Integer, primary_key=True, index=True)
+    user_id = Column(Integer, ForeignKey("users.id", ondelete="CASCADE"), nullable=False, index=True)
+    token = Column(String(128), unique=True, nullable=False, index=True)
+    expires_at = Column(DateTime(timezone=True), nullable=False)
+    revoked = Column(Boolean, default=False, nullable=False)
+    created_at = Column(DateTime(timezone=True), server_default=func.now())
+
+    user = relationship("User", back_populates="refresh_tokens")

--- a/backend/app/models/user.py
+++ b/backend/app/models/user.py
@@ -42,6 +42,11 @@ class User(Base):
         back_populates="user",
         cascade="all, delete-orphan",
     )
+    refresh_tokens = relationship(
+        "RefreshToken",
+        back_populates="user",
+        cascade="all, delete-orphan",
+    )
 
     @property
     def qualified_name(self) -> str:

--- a/backend/app/schemas/token.py
+++ b/backend/app/schemas/token.py
@@ -5,5 +5,16 @@ from app.schemas.user import UserResponse
 
 class Token(BaseModel):
     access_token: str
+    refresh_token: str
     token_type: str
     user: UserResponse
+
+
+class RefreshRequest(BaseModel):
+    refresh_token: str
+
+
+class RefreshResponse(BaseModel):
+    access_token: str
+    refresh_token: str
+    token_type: str = "bearer"

--- a/backend/app/services/auth_service.py
+++ b/backend/app/services/auth_service.py
@@ -9,6 +9,7 @@ tokens are accepted; the remote branch is a comment marking where federation
 would hook in.
 """
 
+import secrets
 from datetime import datetime, timedelta, timezone
 
 import bcrypt
@@ -85,3 +86,41 @@ def get_user_from_token(token: str, db: Session) -> User | None:
     # Future: federated user from another server
     # return federated_user_service.resolve(payload, db)
     return None
+
+
+# ── Refresh Token ──────────────────────────────────────────────────────────────
+
+
+def create_refresh_token(user: User, db: Session) -> str:
+    """Issue a new opaque refresh token, persist it, and return the raw value."""
+    from app.models.refresh_token import RefreshToken
+
+    raw = secrets.token_hex(64)  # 128 hex chars, 256 bits of entropy
+    expires = datetime.now(timezone.utc) + timedelta(days=settings.REFRESH_TOKEN_EXPIRE_DAYS)
+    db.add(RefreshToken(user_id=user.id, token=raw, expires_at=expires))
+    db.commit()
+    return raw
+
+
+def validate_refresh_token(token: str, db: Session) -> User | None:
+    """Return the active user for a valid refresh token, or None."""
+    from app.models.refresh_token import RefreshToken
+
+    rt = (
+        db.query(RefreshToken)
+        .filter(RefreshToken.token == token, RefreshToken.revoked == False)  # noqa: E712
+        .first()
+    )
+    if rt is None or rt.expires_at < datetime.now(timezone.utc):
+        return None
+    return db.query(User).filter(User.id == rt.user_id, User.is_active == True).first()  # noqa: E712
+
+
+def revoke_refresh_token(token: str, db: Session) -> None:
+    """Mark a refresh token as revoked."""
+    from app.models.refresh_token import RefreshToken
+
+    rt = db.query(RefreshToken).filter(RefreshToken.token == token).first()
+    if rt:
+        rt.revoked = True
+        db.commit()

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -9,16 +9,70 @@ api.interceptors.request.use((config) => {
   return config
 })
 
-// On 401, clear auth and redirect to login
+// Queue of callbacks waiting for an in-flight refresh to complete
+let isRefreshing = false
+let refreshQueue = []
+
+function processQueue(error, token = null) {
+  refreshQueue.forEach(({ resolve, reject }) => {
+    if (error) reject(error)
+    else resolve(token)
+  })
+  refreshQueue = []
+}
+
+// On 401: silently refresh the access token using the refresh token.
+// If no refresh token is stored, or if the refresh itself fails, clear
+// auth state and redirect to the login page.
 api.interceptors.response.use(
   (res) => res,
-  (err) => {
-    if (err.response?.status === 401) {
+  async (err) => {
+    const originalRequest = err.config
+
+    if (err.response?.status !== 401 || originalRequest._retry) {
+      return Promise.reject(err)
+    }
+
+    const storedRefresh = localStorage.getItem('refresh_token')
+    if (!storedRefresh) {
       localStorage.removeItem('token')
       window.location.href = '/'
+      return Promise.reject(err)
     }
-    return Promise.reject(err)
-  }
+
+    // If a refresh is already in flight, queue this request to retry afterwards
+    if (isRefreshing) {
+      return new Promise((resolve, reject) => {
+        refreshQueue.push({ resolve, reject })
+      }).then((newToken) => {
+        originalRequest.headers.Authorization = `Bearer ${newToken}`
+        return api(originalRequest)
+      })
+    }
+
+    originalRequest._retry = true
+    isRefreshing = true
+
+    try {
+      // Use raw axios (not `api`) to avoid triggering this interceptor again
+      const { data } = await axios.post('/api/auth/refresh', {
+        refresh_token: storedRefresh,
+      })
+      localStorage.setItem('token', data.access_token)
+      localStorage.setItem('refresh_token', data.refresh_token)
+      processQueue(null, data.access_token)
+      originalRequest.headers.Authorization = `Bearer ${data.access_token}`
+      return api(originalRequest)
+    } catch (refreshErr) {
+      processQueue(refreshErr)
+      localStorage.removeItem('token')
+      localStorage.removeItem('refresh_token')
+      window.location.href = '/'
+      return Promise.reject(refreshErr)
+    } finally {
+      isRefreshing = false
+    }
+  },
 )
 
 export default api

--- a/frontend/src/services/auth.js
+++ b/frontend/src/services/auth.js
@@ -7,3 +7,6 @@ export const login = (username, password) =>
   api.post('/auth/login', { username, password })
 
 export const getMe = () => api.get('/auth/me')
+
+export const revokeToken = (refreshToken) =>
+  api.post('/auth/logout', { refresh_token: refreshToken })

--- a/frontend/src/store/authStore.js
+++ b/frontend/src/store/authStore.js
@@ -1,5 +1,5 @@
 import { create } from 'zustand'
-import { login as apiLogin, register as apiRegister, getMe } from '../services/auth'
+import { login as apiLogin, register as apiRegister, getMe, revokeToken } from '../services/auth'
 
 const useAuthStore = create((set) => ({
   user: null,
@@ -12,6 +12,7 @@ const useAuthStore = create((set) => ({
     try {
       const { data } = await apiLogin(username, password)
       localStorage.setItem('token', data.access_token)
+      localStorage.setItem('refresh_token', data.refresh_token)
       set({ user: data.user, token: data.access_token, loading: false })
     } catch (err) {
       set({ error: err.response?.data?.detail ?? 'Login failed', loading: false })
@@ -23,6 +24,7 @@ const useAuthStore = create((set) => ({
     try {
       const { data } = await apiRegister(username, email, password)
       localStorage.setItem('token', data.access_token)
+      localStorage.setItem('refresh_token', data.refresh_token)
       set({ user: data.user, token: data.access_token, loading: false })
     } catch (err) {
       const detail = err.response?.data?.detail
@@ -40,13 +42,25 @@ const useAuthStore = create((set) => ({
       const { data } = await getMe()
       set({ user: data, token })
     } catch {
+      // getMe() returning an error here means even the silent refresh failed
+      // (api.js interceptor already attempted it). Clear everything.
       localStorage.removeItem('token')
+      localStorage.removeItem('refresh_token')
       set({ user: null, token: null })
     }
   },
 
-  logout: () => {
+  logout: async () => {
+    const refreshToken = localStorage.getItem('refresh_token')
+    if (refreshToken) {
+      try {
+        await revokeToken(refreshToken)
+      } catch {
+        // best-effort — clear local state regardless
+      }
+    }
     localStorage.removeItem('token')
+    localStorage.removeItem('refresh_token')
     set({ user: null, token: null })
   },
 


### PR DESCRIPTION
The 30-minute JWT expiry was silently logging users out of the PWA, breaking push notification delivery for backgrounded sessions.

Backend:
- Add RefreshToken model (user_id, token, expires_at, revoked)
- POST /api/auth/refresh — validates token, rotates pair, returns new both
- POST /api/auth/logout  — revokes the stored refresh token server-side
- login + register now return refresh_token alongside access_token
- REFRESH_TOKEN_EXPIRE_DAYS = 30 (env-overridable)
- Migration 013_add_refresh_tokens

Frontend:
- api.js 401 interceptor: silently refreshes and retries the original request before falling back to redirect; queues concurrent 401s so only one refresh flight runs at a time
- authStore: persist refresh_token in localStorage; logout revokes server-side before clearing local state
- services/auth.js: add revokeToken helper