### PR TITLE
fix: Group A QoL bugs (#47 #50 #51 #57 #58)

### DIFF
--- a/frontend/src/components/Chat/ChannelList.jsx
+++ b/frontend/src/components/Chat/ChannelList.jsx
@@ -35,7 +35,11 @@ export default function ChannelList({ onNavigate }) {
       setName('')
       setDesc('')
     } catch (err) {
-      setError(err.response?.data?.detail ?? 'Failed to create channel')
+      const detail = err.response?.data?.detail
+      const msg = Array.isArray(detail)
+        ? detail.map((d) => d.msg).join(', ')
+        : (detail ?? 'Failed to create channel')
+      setError(msg)
     } finally {
       setCreating(false)
     }

--- a/frontend/src/components/Chat/Message.jsx
+++ b/frontend/src/components/Chat/Message.jsx
@@ -158,6 +158,7 @@ export default function Message({ message }) {
   const [editContent, setEditContent] = useState(message.content)
   const [showActions, setShowActions] = useState(false)
   const [showReactionPicker, setShowReactionPicker] = useState(false)
+  const [reactionPickerClass, setReactionPickerClass] = useState('bottom-full right-0')
   const [profileUserId, setProfileUserId] = useState(null)
   const reactionButtonRef = useRef(null)
 
@@ -276,7 +277,16 @@ export default function Message({ message }) {
           <button
             ref={reactionButtonRef}
             onMouseDown={(e) => e.preventDefault()}
-            onClick={() => setShowReactionPicker((v) => !v)}
+            onClick={() => {
+              if (!showReactionPicker) {
+                const rect = reactionButtonRef.current?.getBoundingClientRect()
+                // Emoji picker is ~435px tall; open downward if insufficient space above
+                setReactionPickerClass(
+                  rect && rect.top > 435 ? 'bottom-full right-0' : 'top-full right-0'
+                )
+              }
+              setShowReactionPicker((v) => !v)
+            }}
             className="text-xs text-[var(--text-muted)] hover:text-[var(--accent-teal)] transition-colors px-1"
             title="Add reaction"
             data-testid="add-reaction-button"
@@ -289,7 +299,7 @@ export default function Message({ message }) {
               onSelect={(emoji) => addReaction(message.id, emoji)}
               onClose={() => setShowReactionPicker(false)}
               anchorRef={reactionButtonRef}
-              positionClass="bottom-full right-0"
+              positionClass={reactionPickerClass}
             />
           )}
 

--- a/frontend/src/components/Chat/MessageInput.jsx
+++ b/frontend/src/components/Chat/MessageInput.jsx
@@ -132,7 +132,7 @@ export default function MessageInput({ onTyping }) {
       mentionTimerRef.current = setTimeout(async () => {
         if (!activeChannelId) return
         try {
-          const { data } = await getChannelMembers(activeChannelId, m.query || undefined)
+          const { data } = await getChannelMembers(activeServerId, activeChannelId, m.query || undefined)
           const members = data.slice(0, 6)
           // Prepend @all if the typed prefix is compatible (empty, or starts with 'all')
           const q = m.query.toLowerCase()

--- a/frontend/src/components/Common/TwemojiEmoji.jsx
+++ b/frontend/src/components/Common/TwemojiEmoji.jsx
@@ -16,6 +16,15 @@ export default function TwemojiEmoji({ emoji, size = '1.2em', className = '' }) 
   const codepoint = twemoji.convert.toCodePoint(emoji)
   const src = `${TWEMOJI_SVG_BASE}${codepoint}.svg`
 
+  // Some emojis (e.g. ❤️) get a codepoint with a `-fe0f` variation selector
+  // that Twemoji CDN files don't include. Fall back to the base codepoint.
+  const handleError = (e) => {
+    const current = e.currentTarget.src
+    if (current.includes('-fe0f')) {
+      e.currentTarget.src = current.replace(/-fe0f/g, '')
+    }
+  }
+
   return (
     <img
       src={src}
@@ -28,6 +37,7 @@ export default function TwemojiEmoji({ emoji, size = '1.2em', className = '' }) 
         verticalAlign: '-0.15em',
       }}
       draggable={false}
+      onError={handleError}
     />
   )
 }

--- a/frontend/src/hooks/useWebSocket.js
+++ b/frontend/src/hooks/useWebSocket.js
@@ -72,19 +72,21 @@ export function useWebSocket(serverId, token) {
       const activeChannelId = useChatStore.getState().activeChannelId
 
       switch (data.type) {
-        case 'message.new':
+        case 'message.new': {
+          const isOwnMessage = me && data.message?.user_id === me.id
           if (channelId === activeChannelId) {
             appendMessageForChannel(channelId, data.message)
-          } else {
+          } else if (!isOwnMessage) {
             incrementUnread(channelId)
           }
-          if (me && isMention(data.message?.content, me.username)) {
+          if (!isOwnMessage && me && isMention(data.message?.content, me.username)) {
             showNotification(
               `@${me.username} mentioned by ${data.message?.user?.username}`,
               { body: data.message?.content, tag: `mention-${data.message?.id}` }
             )
           }
           break
+        }
         case 'message.updated':
           updateMessage(data.message)
           break


### PR DESCRIPTION
- #57: Fix @mention autocomplete — getChannelMembers was called with wrong arity (missing activeServerId as first arg), so all member searches returned empty results
- #47: TwemojiEmoji — add onError fallback that strips the -fe0f variation selector from the CDN URL (e.g. ❤️ → 2764-fe0f.svg → 2764.svg) so heart and similar emojis render instead of showing broken image
- #58: ChannelList channel-create error — Pydantic validation errors arrive as an array; flatten to a string so React doesn't render [object Object] and throw an error
- #51: useWebSocket — skip incrementUnread and mention notification for messages sent by the current user, preventing own messages from showing unread badges on other connected devices
- #50: Reaction emoji picker — compute open direction at click time based on the button's viewport position; opens upward (bottom-full) when there is enough space above, downward (top-full) otherwise