### PR TITLE
feat: Group C DM features (#48 #52)

### DIFF
--- a/backend/app/api/dms.py
+++ b/backend/app/api/dms.py
@@ -6,6 +6,7 @@ from sqlalchemy.orm import Session
 
 from app.api.deps import get_current_user
 from app.database import get_db
+from app.models.attachment import Attachment
 from app.models.dm_channel import DirectMessageChannel
 from app.models.message import Message
 from app.models.user import User
@@ -102,7 +103,8 @@ async def send_dm_message(
     if current_user.id not in (dm.user1_id, dm.user2_id):
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Not a participant")
 
-    if not message_in.content or not message_in.content.strip():
+    has_content = bool(message_in.content and message_in.content.strip())
+    if not has_content and not message_in.attachment_ids:
         raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail="Message cannot be empty")
 
     # Validate reply_to_id if provided
@@ -120,7 +122,7 @@ async def send_dm_message(
             raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Parent message not found")
 
     msg = Message(
-        content=message_in.content.strip(),
+        content=message_in.content.strip() if has_content else "",
         user_id=current_user.id,
         dm_channel_id=dm_id,
         reply_to_id=message_in.reply_to_id,
@@ -130,6 +132,15 @@ async def send_dm_message(
     dm.last_message_at = datetime.now(timezone.utc)
     db.commit()
     db.refresh(msg)
+
+    if message_in.attachment_ids:
+        db.query(Attachment).filter(
+            Attachment.id.in_(message_in.attachment_ids),
+            Attachment.user_id == current_user.id,
+            Attachment.message_id.is_(None),
+        ).update({"message_id": msg.id}, synchronize_session=False)
+        db.commit()
+        db.refresh(msg)
 
     response = MessageResponse.model_validate(msg)
 

--- a/backend/app/schemas/dm_channel.py
+++ b/backend/app/schemas/dm_channel.py
@@ -15,5 +15,6 @@ class DMChannelResponse(BaseModel):
 
 
 class DMMessageCreate(BaseModel):
-    content: str
+    content: str | None = None
     reply_to_id: int | None = None
+    attachment_ids: list[int] = []

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -18,6 +18,7 @@ import { OperatorDashboard } from './pages/OperatorDashboard'
 import { useFaviconBadge } from './hooks/useFaviconBadge'
 import { useInviteModal } from './hooks/useInviteModal'
 import { useVoiceWebSocket } from './hooks/useVoiceWebSocket'
+import { useDMNotifications } from './hooks/useDMNotifications'
 
 // Detect special routes at module load time (before any React rendering)
 const pathname = window.location.pathname
@@ -32,6 +33,7 @@ function ChatLayout() {
   const [sidebarOpen, setSidebarOpen] = useState(true)
 
   const { sendVoiceMsg, voiceConnected } = useVoiceWebSocket(token)
+  useDMNotifications()
   const invite = useInviteModal()
 
   const handleNavigate = () => setSidebarOpen(false)

--- a/frontend/src/components/Chat/DMView.jsx
+++ b/frontend/src/components/Chat/DMView.jsx
@@ -1,33 +1,75 @@
-import { useState, useRef, useEffect } from 'react'
+import { useState, useRef, useEffect, useCallback } from 'react'
 import useDMStore from '../../store/dmStore'
 import useAuthStore from '../../store/authStore'
 import { useWebSocketDM } from '../../hooks/useWebSocketDM'
+import { attachGif } from '../../services/gifs'
 import Message from './Message'
+import GifPicker from './GifPicker'
+import EmojiPicker from './EmojiPicker'
 
 function DMInput({ dmId }) {
   const [content, setContent] = useState('')
+  const [gifAttachmentId, setGifAttachmentId] = useState(null)
+  const [showGifPicker, setShowGifPicker] = useState(false)
+  const [showEmojiPicker, setShowEmojiPicker] = useState(false)
   const textareaRef = useRef(null)
+  const emojiButtonRef = useRef(null)
+  const selectionRef = useRef({ start: 0, end: 0 })
   const { sendDMMessage } = useDMStore()
 
-  const canSubmit = content.trim().length > 0
+  const canSubmit = content.trim().length > 0 || gifAttachmentId != null
 
   const submit = async () => {
     if (!canSubmit) return
-    const text = content.trim()
+    const text = content.trim() || null
+    const attachmentIds = gifAttachmentId ? [gifAttachmentId] : []
     setContent('')
+    setGifAttachmentId(null)
     if (textareaRef.current) textareaRef.current.style.height = 'auto'
     try {
-      await sendDMMessage(text)
+      await sendDMMessage(text, attachmentIds)
     } catch (err) {
       console.error('DM send failed', err)
     }
   }
+
+  const saveSelection = useCallback(() => {
+    const el = textareaRef.current
+    if (el) selectionRef.current = { start: el.selectionStart, end: el.selectionEnd }
+  }, [])
+
+  const insertEmoji = useCallback((emoji) => {
+    saveSelection()
+    const { start, end } = selectionRef.current
+    setContent((prev) => prev.slice(0, start) + emoji + prev.slice(end))
+    const nextPos = start + [...emoji].length
+    selectionRef.current = { start: nextPos, end: nextPos }
+    requestAnimationFrame(() => {
+      const el = textareaRef.current
+      if (el) {
+        el.focus()
+        el.selectionStart = nextPos
+        el.selectionEnd = nextPos
+      }
+    })
+  }, [saveSelection])
+
+  const handleGifSelect = useCallback(async (gif) => {
+    setShowGifPicker(false)
+    try {
+      const { data } = await attachGif(gif)
+      setGifAttachmentId(data.id)
+    } catch {
+      // ignore — gif attach failure is non-fatal
+    }
+  }, [])
 
   const handleChange = (e) => {
     setContent(e.target.value)
     const el = textareaRef.current
     el.style.height = 'auto'
     el.style.height = Math.min(el.scrollHeight, 160) + 'px'
+    saveSelection()
   }
 
   const handleKeyDown = (e) => {
@@ -38,40 +80,108 @@ function DMInput({ dmId }) {
   }
 
   return (
-    <div className="border-t border-[var(--border)] bg-black/20 flex-shrink-0 px-4 py-3 flex gap-2 items-end">
-      <textarea
-        ref={textareaRef}
-        value={content}
-        onChange={handleChange}
-        onKeyDown={handleKeyDown}
-        placeholder="Message…  (Enter to send, Shift+Enter for newline)"
-        rows={1}
-        className="
-          flex-1 bg-black/40 border border-[var(--border)] rounded
-          text-[var(--text-primary)] font-mono text-sm px-3 py-2
-          placeholder:text-[var(--text-muted)]
-          focus:outline-none focus:border-[var(--border-glow)]
-          focus:shadow-[0_0_12px_rgba(0,206,209,0.3)]
-          resize-none transition-all duration-200 leading-relaxed
-        "
-        data-testid="dm-input"
-      />
-      <button
-        onClick={submit}
-        disabled={!canSubmit}
-        className="
-          h-9 w-9 flex items-center justify-center rounded
-          bg-gradient-to-br from-crt-teal to-crt-teal-lt
-          text-crt-bg shadow-glow-sm
-          hover:shadow-glow hover:-translate-y-px
-          disabled:opacity-30 disabled:cursor-not-allowed disabled:shadow-none disabled:translate-y-0
-          transition-all duration-200 flex-shrink-0
-        "
-        title="Send (Enter)"
-        data-testid="dm-send-button"
-      >
-        ➤
-      </button>
+    <div className="border-t border-[var(--border)] bg-black/20 flex-shrink-0">
+      {/* GIF attached indicator */}
+      {gifAttachmentId && (
+        <div className="px-4 pt-2 flex items-center gap-2 text-xs font-mono text-[var(--text-muted)]">
+          <span>GIF attached</span>
+          <button
+            onClick={() => setGifAttachmentId(null)}
+            className="text-[var(--text-muted)] hover:text-[var(--text-error)] transition-colors"
+          >
+            ✕
+          </button>
+        </div>
+      )}
+
+      <div className="px-4 py-3 flex gap-2 items-end relative">
+        {/* GIF picker (positioned above) */}
+        {showGifPicker && (
+          <GifPicker
+            onSelect={handleGifSelect}
+            onClose={() => setShowGifPicker(false)}
+          />
+        )}
+
+        {/* Emoji picker (positioned above) */}
+        {showEmojiPicker && (
+          <EmojiPicker
+            onSelect={insertEmoji}
+            onClose={() => setShowEmojiPicker(false)}
+            anchorRef={emojiButtonRef}
+          />
+        )}
+
+        {/* GIF button */}
+        <button
+          onClick={() => setShowGifPicker((v) => !v)}
+          className="
+            h-9 px-2 flex items-center justify-center rounded flex-shrink-0
+            border border-[var(--border)] text-[var(--text-muted)]
+            hover:text-[var(--accent-teal)] hover:border-[var(--border-glow)]
+            hover:shadow-[0_0_8px_rgba(0,206,209,0.2)]
+            transition-all duration-200 font-mono text-xs font-bold
+          "
+          title="Insert GIF"
+          data-testid="dm-gif-button"
+        >
+          GIF
+        </button>
+
+        {/* Emoji button */}
+        <button
+          ref={emojiButtonRef}
+          onMouseDown={(e) => e.preventDefault()}
+          onClick={() => setShowEmojiPicker((v) => !v)}
+          className="
+            h-9 w-9 flex items-center justify-center rounded flex-shrink-0
+            border border-[var(--border)] text-[var(--text-muted)]
+            hover:text-[var(--accent-teal)] hover:border-[var(--border-glow)]
+            hover:shadow-[0_0_8px_rgba(0,206,209,0.2)]
+            transition-all duration-200 text-base
+          "
+          title="Insert emoji"
+          data-testid="dm-emoji-button"
+        >
+          😊
+        </button>
+
+        <textarea
+          ref={textareaRef}
+          value={content}
+          onChange={handleChange}
+          onKeyDown={handleKeyDown}
+          onSelect={saveSelection}
+          onBlur={saveSelection}
+          placeholder="Message…  (Enter to send, Shift+Enter for newline)"
+          rows={1}
+          className="
+            flex-1 bg-black/40 border border-[var(--border)] rounded
+            text-[var(--text-primary)] font-mono text-sm px-3 py-2
+            placeholder:text-[var(--text-muted)]
+            focus:outline-none focus:border-[var(--border-glow)]
+            focus:shadow-[0_0_12px_rgba(0,206,209,0.3)]
+            resize-none overflow-y-hidden transition-colors duration-200 leading-relaxed
+          "
+          data-testid="dm-input"
+        />
+        <button
+          onClick={submit}
+          disabled={!canSubmit}
+          className="
+            h-9 w-9 flex items-center justify-center rounded
+            bg-gradient-to-br from-crt-teal to-crt-teal-lt
+            text-crt-bg shadow-glow-sm
+            hover:shadow-glow hover:-translate-y-px
+            disabled:opacity-30 disabled:cursor-not-allowed disabled:shadow-none disabled:translate-y-0
+            transition-all duration-200 flex-shrink-0
+          "
+          title="Send (Enter)"
+          data-testid="dm-send-button"
+        >
+          ➤
+        </button>
+      </div>
     </div>
   )
 }

--- a/frontend/src/components/Chat/DMView.test.jsx
+++ b/frontend/src/components/Chat/DMView.test.jsx
@@ -106,7 +106,7 @@ describe('DMView', () => {
     const input = screen.getByTestId('dm-input')
     await userEvent.type(input, 'hello')
     fireEvent.keyDown(input, { key: 'Enter', shiftKey: false })
-    expect(mockSendDMMessage).toHaveBeenCalledWith('hello')
+    expect(mockSendDMMessage).toHaveBeenCalledWith('hello', [])
   })
 
   it('clears input after sending', async () => {

--- a/frontend/src/hooks/useDMNotifications.js
+++ b/frontend/src/hooks/useDMNotifications.js
@@ -1,0 +1,74 @@
+/**
+ * useDMNotifications — global DM background listener.
+ *
+ * Maintains one WebSocket connection per DM channel that the user is NOT
+ * currently viewing.  When a new message arrives from the other participant
+ * it fires a browser notification.  The active DM (if any) is handled by
+ * useWebSocketDM inside DMView; this hook covers the rest so users still get
+ * notified while browsing a server channel.
+ */
+import { useEffect, useRef } from 'react'
+import useDMStore from '../store/dmStore'
+import useAuthStore from '../store/authStore'
+import { showNotification } from '../utils/notifications'
+
+export function useDMNotifications() {
+  const token = useAuthStore((s) => s.token)
+  const me = useAuthStore((s) => s.user)
+  const dms = useDMStore((s) => s.dms)
+  const activeDmId = useDMStore((s) => s.activeDmId)
+  const appendDMMessage = useDMStore((s) => s.appendDMMessage)
+  // Map of dm_id -> WebSocket
+  const wsRefs = useRef({})
+
+  useEffect(() => {
+    if (!token || !me) return
+
+    const currentIds = new Set(dms.map((d) => d.id))
+
+    // Open connections for DMs not currently active and not yet connected
+    dms.forEach((dm) => {
+      if (dm.id === activeDmId) return  // DMView's useWebSocketDM handles this
+      if (wsRefs.current[dm.id]) return  // already open
+
+      const proto = window.location.protocol === 'https:' ? 'wss' : 'ws'
+      const ws = new WebSocket(`${proto}://${window.location.host}/ws/dm/${dm.id}`)
+      wsRefs.current[dm.id] = ws
+
+      ws.onopen = () => ws.send(JSON.stringify({ type: 'auth', token }))
+
+      ws.onmessage = (ev) => {
+        try {
+          const data = JSON.parse(ev.data)
+          if (data.type === 'message.new' && data.message?.user_id !== me.id) {
+            appendDMMessage(data.message)
+            showNotification(`DM from ${data.message?.user?.username}`, {
+              body: data.message?.content,
+              tag: `dm-${data.message?.id}`,
+            })
+          }
+        } catch { /* ignore parse errors */ }
+      }
+
+      ws.onclose = () => { delete wsRefs.current[dm.id] }
+      ws.onerror = () => ws.close()
+    })
+
+    // Close connections for DMs that no longer exist or became active
+    Object.keys(wsRefs.current).forEach((idStr) => {
+      const id = Number(idStr)
+      if (!currentIds.has(id) || id === activeDmId) {
+        wsRefs.current[id]?.close()
+        delete wsRefs.current[id]
+      }
+    })
+  }, [token, me, dms, activeDmId, appendDMMessage])
+
+  // Close all connections on logout / unmount
+  useEffect(() => {
+    return () => {
+      Object.values(wsRefs.current).forEach((ws) => ws.close())
+      wsRefs.current = {}
+    }
+  }, [])
+}

--- a/frontend/src/services/directMessages.js
+++ b/frontend/src/services/directMessages.js
@@ -3,8 +3,9 @@ import api from './api'
 export const listDMs = () => api.get('/dms')
 export const getOrCreateDM = (otherUserId) => api.post(`/dms?other_user_id=${otherUserId}`)
 export const getDMMessages = (dmId, params) => api.get(`/dms/${dmId}/messages`, { params })
-export const sendDMMessage = (dmId, content, replyToId = null) =>
+export const sendDMMessage = (dmId, content, attachmentIds = [], replyToId = null) =>
   api.post(`/dms/${dmId}/messages`, {
-    content,
+    ...(content != null && { content }),
+    attachment_ids: attachmentIds,
     ...(replyToId != null && { reply_to_id: replyToId }),
   })

--- a/frontend/src/store/dmStore.js
+++ b/frontend/src/store/dmStore.js
@@ -51,10 +51,10 @@ const useDMStore = create((set, get) => ({
     }
   },
 
-  sendDMMessage: async (content, replyToId = null) => {
+  sendDMMessage: async (content, attachmentIds = [], replyToId = null) => {
     const { activeDmId } = get()
     if (!activeDmId) return
-    await sendDMMessage(activeDmId, content, replyToId)
+    await sendDMMessage(activeDmId, content, attachmentIds, replyToId)
     get().fetchDMMessages(activeDmId)
   },
 


### PR DESCRIPTION
#48 — Emojis and GIFs now available in DMs:
- Backend: DMMessageCreate now accepts optional content and attachment_ids; send_dm_message validates that at least one of (content, attachments) is present and links attachment records to the new message (mirrors channels)
- Frontend: directMessages service and dmStore thread attachment_ids through; DMInput gains emoji picker and GIF picker matching the server channel UX

#52 — DM notifications now fire when not actively viewing that DM:
- New useDMNotifications hook maintains one background WebSocket per DM channel that isn't currently open; fires a browser notification on incoming messages from others and updates the store
- Hook is called from ChatLayout (always active while logged in), so users browsing a server channel still receive DM notifications in real time