### PR TITLE
fix: Group D+E — server icon size, labels, channel/server management UI

### DIFF
--- a/frontend/src/components/Layout/Sidebar.jsx
+++ b/frontend/src/components/Layout/Sidebar.jsx
@@ -7,6 +7,7 @@ import StatusIndicator from '../Common/StatusIndicator'
 import useAuthStore from '../../store/authStore'
 import useDMStore from '../../store/dmStore'
 import useChatStore from '../../store/chatStore'
+import useServerStore from '../../store/serverStore'
 
 function Avatar({ username, avatarUrl }) {
   if (avatarUrl) {
@@ -31,6 +32,7 @@ export default function Sidebar({ onSearchOpen, onNavigate, mobileHidden }) {
   const { user, logout } = useAuthStore()
   const { fetchDMs, selectDM } = useDMStore()
   const clearActiveChannel = useChatStore((s) => s.clearActiveChannel)
+  const activeServer = useServerStore((s) => s.servers.find((sv) => sv.id === s.activeServerId))
   const [showNewDM, setShowNewDM] = useState(false)
   const [showProfile, setShowProfile] = useState(false)
 
@@ -72,8 +74,8 @@ export default function Sidebar({ onSearchOpen, onNavigate, mobileHidden }) {
       {/* Channel list */}
       <div className="flex-1 min-h-0 py-2 overflow-y-auto flex flex-col">
         <div>
-          <p className="px-4 pb-1 text-[10px] font-mono text-[var(--text-muted)] uppercase tracking-widest">
-            channels
+          <p className="px-4 pb-1 text-[10px] font-mono text-[var(--text-muted)] uppercase tracking-widest truncate">
+            {activeServer?.name ?? 'channels'}
           </p>
           <ChannelList onNavigate={onNavigate} />
         </div>

--- a/frontend/src/components/Server/ServerSettingsModal.jsx
+++ b/frontend/src/components/Server/ServerSettingsModal.jsx
@@ -1,6 +1,8 @@
-import { useRef, useState } from 'react'
+import { useRef, useState, useEffect } from 'react'
 import useServerStore from '../../store/serverStore'
-import { uploadServerIcon } from '../../services/servers'
+import useChatStore from '../../store/chatStore'
+import useAuthStore from '../../store/authStore'
+import { uploadServerIcon, listMembers } from '../../services/servers'
 import { InviteForm } from './InviteForm'
 
 function AppearanceTab({ server }) {
@@ -90,6 +92,304 @@ function AppearanceTab({ server }) {
   )
 }
 
+function MembersTab({ server, onClose }) {
+  const me = useAuthStore((s) => s.user)
+  const updateMemberRole = useServerStore((s) => s.updateMemberRole)
+  const removeMember = useServerStore((s) => s.removeMember)
+  const transferOwnership = useServerStore((s) => s.transferOwnership)
+  const deleteServer = useServerStore((s) => s.deleteServer)
+  const [members, setMembers] = useState([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState('')
+  const [confirmKick, setConfirmKick] = useState(null)
+  const [confirmTransfer, setConfirmTransfer] = useState(null)
+  const [confirmDelete, setConfirmDelete] = useState(false)
+  const [working, setWorking] = useState(false)
+
+  const isOwner = server?.current_user_role === 'owner'
+  const isAdmin = server?.current_user_role === 'admin'
+
+  useEffect(() => {
+    if (!server?.id) return
+    listMembers(server.id)
+      .then(({ data }) => setMembers(data))
+      .catch(() => setError('Failed to load members'))
+      .finally(() => setLoading(false))
+  }, [server?.id])
+
+  const handleRoleChange = async (userId, newRole) => {
+    try {
+      await updateMemberRole(server.id, userId, newRole)
+      setMembers((ms) => ms.map((m) => m.user_id === userId ? { ...m, role: newRole } : m))
+    } catch {
+      setError('Failed to update role')
+    }
+  }
+
+  const handleKick = async () => {
+    if (!confirmKick) return
+    setWorking(true)
+    try {
+      await removeMember(server.id, confirmKick.user_id)
+      setMembers((ms) => ms.filter((m) => m.user_id !== confirmKick.user_id))
+      setConfirmKick(null)
+    } catch {
+      setError('Failed to remove member')
+    } finally {
+      setWorking(false)
+    }
+  }
+
+  const handleTransfer = async () => {
+    if (!confirmTransfer) return
+    setWorking(true)
+    try {
+      await transferOwnership(server.id, confirmTransfer.user_id)
+      // Refresh the member list (roles changed)
+      const { data } = await listMembers(server.id)
+      setMembers(data)
+      setConfirmTransfer(null)
+    } catch {
+      setError('Failed to transfer ownership')
+    } finally {
+      setWorking(false)
+    }
+  }
+
+  const handleDeleteServer = async () => {
+    setWorking(true)
+    try {
+      await deleteServer(server.id)
+      onClose()
+    } catch {
+      setError('Failed to delete server')
+      setWorking(false)
+      setConfirmDelete(false)
+    }
+  }
+
+  return (
+    <div className="server-settings-modal__section">
+      <h3>Members</h3>
+      {loading && <p className="text-xs font-mono text-[var(--text-muted)] mt-3">Loading…</p>}
+      {error && <p className="text-xs font-mono text-[var(--text-error)] mt-2">&gt; {error}</p>}
+      {!loading && (
+        <ul className="mt-4 flex flex-col gap-1">
+          {members.map((m) => {
+            const isSelf = m.user_id === me?.id
+            const isTheirOwner = m.role === 'owner'
+            return (
+              <li key={m.user_id} className="flex items-center gap-2 px-3 py-2 rounded
+                                              bg-[var(--bg-hover)] text-sm">
+                <span className="flex-1 font-mono text-[var(--text-primary)] truncate">
+                  {m.display_name || m.username}
+                  {isSelf && <span className="text-[var(--text-muted)] text-xs ml-1">(you)</span>}
+                </span>
+                {/* Role badge / selector */}
+                {(isOwner && !isSelf && !isTheirOwner) ? (
+                  <select
+                    value={m.role}
+                    onChange={(e) => handleRoleChange(m.user_id, e.target.value)}
+                    className="text-xs font-mono bg-[var(--bg-secondary)] border border-[var(--border)]
+                               text-[var(--text-muted)] rounded px-1 py-0.5 cursor-pointer"
+                  >
+                    <option value="member">member</option>
+                    <option value="admin">admin</option>
+                  </select>
+                ) : (
+                  <span className={`text-xs font-mono px-1.5 py-0.5 rounded
+                    ${isTheirOwner ? 'text-[var(--crt-orange)]' :
+                      m.role === 'admin' ? 'text-[var(--accent-teal)]' :
+                      'text-[var(--text-muted)]'}`}>
+                    {m.role}
+                  </span>
+                )}
+                {/* Transfer ownership */}
+                {isOwner && !isSelf && !isTheirOwner && (
+                  <button
+                    type="button"
+                    title="Transfer ownership"
+                    onClick={() => setConfirmTransfer(m)}
+                    className="text-xs text-[var(--text-muted)] hover:text-[var(--crt-orange)]
+                               transition-colors font-mono"
+                  >
+                    crown
+                  </button>
+                )}
+                {/* Kick */}
+                {(isOwner || isAdmin) && !isSelf && !isTheirOwner && (
+                  <button
+                    type="button"
+                    title="Remove member"
+                    onClick={() => setConfirmKick(m)}
+                    className="text-xs text-[var(--text-muted)] hover:text-[var(--text-error)]
+                               transition-colors font-mono"
+                  >
+                    kick
+                  </button>
+                )}
+              </li>
+            )
+          })}
+        </ul>
+      )}
+
+      {/* Danger Zone — owner only */}
+      {isOwner && (
+        <div className="mt-8 border border-[var(--text-error)]/30 rounded-lg p-4">
+          <h4 className="text-xs font-mono text-[var(--text-error)] uppercase tracking-widest mb-3">
+            Danger Zone
+          </h4>
+          <div className="flex items-center justify-between">
+            <div>
+              <p className="text-sm text-[var(--text-primary)]">Delete this server</p>
+              <p className="text-xs text-[var(--text-muted)] mt-0.5">
+                Permanently removes the server and all its channels and messages.
+              </p>
+            </div>
+            <button
+              type="button"
+              onClick={() => setConfirmDelete(true)}
+              className="ml-4 px-3 py-1.5 text-xs font-mono rounded
+                         border border-[var(--text-error)]/50 text-[var(--text-error)]
+                         hover:bg-[var(--text-error)]/10 transition-colors flex-shrink-0"
+            >
+              Delete server
+            </button>
+          </div>
+        </div>
+      )}
+
+      {/* Confirmation dialogs */}
+      {confirmKick && (
+        <ConfirmDialog
+          title="Remove Member"
+          message={`Remove ${confirmKick.display_name || confirmKick.username} from ${server?.name}?`}
+          confirmLabel="Remove"
+          danger
+          working={working}
+          onConfirm={handleKick}
+          onCancel={() => setConfirmKick(null)}
+        />
+      )}
+      {confirmTransfer && (
+        <ConfirmDialog
+          title="Transfer Ownership"
+          message={`Transfer ownership of ${server?.name} to ${confirmTransfer.display_name || confirmTransfer.username}? You will become an admin.`}
+          confirmLabel="Transfer"
+          working={working}
+          onConfirm={handleTransfer}
+          onCancel={() => setConfirmTransfer(null)}
+        />
+      )}
+      {confirmDelete && (
+        <ConfirmDialog
+          title="Delete Server"
+          message={`Are you sure you want to delete "${server?.name}"? This will permanently remove all channels and messages. This cannot be undone.`}
+          confirmLabel="Delete Server"
+          danger
+          working={working}
+          onConfirm={handleDeleteServer}
+          onCancel={() => setConfirmDelete(false)}
+        />
+      )}
+    </div>
+  )
+}
+
+function ConfirmDialog({ title, message, confirmLabel, danger = false, working, onConfirm, onCancel }) {
+  return (
+    <div className="fixed inset-0 bg-black/60 flex items-center justify-center z-[60]">
+      <div className="bg-[var(--bg-secondary)] border border-[var(--border)] rounded-lg p-6
+                      max-w-sm w-full mx-4 shadow-xl">
+        <h4 className="text-sm font-bold text-[var(--text-primary)] mb-2">{title}</h4>
+        <p className="text-sm text-[var(--text-lt)] mb-5">{message}</p>
+        <div className="flex justify-end gap-2">
+          <button
+            type="button"
+            onClick={onCancel}
+            className="px-3 py-1.5 text-xs font-mono rounded border border-[var(--border)]
+                       text-[var(--text-muted)] hover:text-[var(--text-primary)] transition-colors"
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            onClick={onConfirm}
+            disabled={working}
+            className={`px-3 py-1.5 text-xs font-mono rounded border disabled:opacity-40
+                        disabled:cursor-not-allowed transition-colors
+                        ${danger
+                          ? 'bg-[var(--text-error)]/20 border-[var(--text-error)]/50 text-[var(--text-error)] hover:bg-[var(--text-error)]/30'
+                          : 'bg-[var(--accent-teal)]/20 border-[var(--accent-teal)]/50 text-[var(--accent-teal)] hover:bg-[var(--accent-teal)]/30'
+                        }`}
+          >
+            {working ? '…' : confirmLabel}
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+function ChannelsTab({ serverId }) {
+  const channels = useChatStore((s) => s.channels)
+  const deleteChannel = useChatStore((s) => s.deleteChannel)
+  const [confirmId, setConfirmId] = useState(null)
+  const [deleting, setDeleting] = useState(false)
+
+  const confirmChannel = channels.find((c) => c.id === confirmId)
+
+  const handleDelete = async () => {
+    setDeleting(true)
+    try {
+      await deleteChannel(serverId, confirmId)
+      setConfirmId(null)
+    } finally {
+      setDeleting(false)
+    }
+  }
+
+  return (
+    <div className="server-settings-modal__section">
+      <h3>Channels</h3>
+      <p className="server-settings-modal__description">
+        Delete channels you no longer need. This action cannot be undone.
+      </p>
+      <ul className="mt-4 flex flex-col gap-1">
+        {channels.map((ch) => (
+          <li key={ch.id} className="flex items-center justify-between px-3 py-2 rounded
+                                     bg-[var(--bg-hover)] font-mono text-sm">
+            <span className="text-[var(--text-muted)]">#</span>
+            <span className="flex-1 ml-1 text-[var(--text-primary)]">{ch.name}</span>
+            <button
+              type="button"
+              title={`Delete #${ch.name}`}
+              onClick={() => setConfirmId(ch.id)}
+              className="text-xs text-[var(--text-muted)] hover:text-[var(--text-error)]
+                         transition-colors px-1 font-mono"
+            >
+              delete
+            </button>
+          </li>
+        ))}
+      </ul>
+
+      {confirmId && (
+        <ConfirmDialog
+          title="Delete Channel"
+          message={`Are you sure you want to delete #${confirmChannel?.name}? All messages will be permanently removed.`}
+          confirmLabel="Delete"
+          danger
+          working={deleting}
+          onConfirm={handleDelete}
+          onCancel={() => setConfirmId(null)}
+        />
+      )}
+    </div>
+  )
+}
+
 export function ServerSettingsModal({ onClose }) {
   const [activeTab, setActiveTab] = useState('appearance')
   const activeServerId = useServerStore((s) => s.activeServerId)
@@ -99,6 +399,8 @@ export function ServerSettingsModal({ onClose }) {
   const tabs = [
     { id: 'appearance', label: 'Appearance' },
     { id: 'invite', label: 'Invite People' },
+    { id: 'channels', label: 'Channels' },
+    { id: 'members', label: 'Members' },
   ]
 
   return (
@@ -137,6 +439,8 @@ export function ServerSettingsModal({ onClose }) {
               <InviteForm serverId={activeServerId} serverName={server?.name} />
             </div>
           )}
+          {activeTab === 'channels' && <ChannelsTab serverId={activeServerId} />}
+          {activeTab === 'members' && <MembersTab server={server} onClose={onClose} />}
         </div>
       </div>
     </div>

--- a/frontend/src/store/chatStore.js
+++ b/frontend/src/store/chatStore.js
@@ -1,5 +1,5 @@
 import { create } from 'zustand'
-import { listChannels, createChannel, getMessages, sendMessage, markChannelRead } from '../services/channels'
+import { listChannels, createChannel, deleteChannel, getMessages, sendMessage, markChannelRead } from '../services/channels'
 import { addReaction, removeReaction, editMessage, deleteMessage } from '../services/messages'
 
 let _nextTempId = 1
@@ -38,6 +38,24 @@ const useChatStore = create((set, get) => ({
     const { data } = await createChannel(serverId, name, description)
     set((s) => ({ channels: [...s.channels, data] }))
     get().selectChannel(serverId, data.id)
+  },
+
+  deleteChannel: async (serverId, channelId) => {
+    await deleteChannel(serverId, channelId)
+    set((s) => {
+      const channels = s.channels.filter((c) => c.id !== channelId)
+      // If the deleted channel was active, switch to another
+      if (s.activeChannelId === channelId) {
+        const next = channels[0]
+        return { channels, activeChannelId: next?.id ?? null, messages: [], messagesTotal: 0 }
+      }
+      return { channels }
+    })
+    // Fetch messages for newly-active channel if needed
+    const { activeChannelId, channels } = get()
+    if (activeChannelId) {
+      get().fetchMessages(serverId, activeChannelId)
+    }
   },
 
   selectChannel: async (serverId, channelId) => {

--- a/frontend/src/store/serverStore.js
+++ b/frontend/src/store/serverStore.js
@@ -1,5 +1,5 @@
 import { create } from 'zustand'
-import { listServers } from '../services/servers'
+import { listServers, deleteServer, updateMemberRole, removeMember, transferOwnership } from '../services/servers'
 
 // Lazy imports to avoid circular dependency at module load time.
 // chatStore and useWebSocket are imported inside actions that need them.
@@ -55,6 +55,24 @@ const useServerStore = create((set, get) => ({
             : s.activeServerId,
       }
     }),
+
+  deleteServer: async (serverId) => {
+    await deleteServer(serverId)
+    get().removeServer(serverId)
+    const remaining = get().servers
+    if (remaining.length > 0 && !get().activeServerId) {
+      get().setActiveServer(remaining[0].id)
+    }
+  },
+
+  updateMemberRole: (serverId, userId, role) => updateMemberRole(serverId, userId, role),
+
+  removeMember: (serverId, userId) => removeMember(serverId, userId),
+
+  transferOwnership: async (serverId, newOwnerId) => {
+    const { data } = await transferOwnership(serverId, newOwnerId)
+    get().updateServer(data)
+  },
 }))
 
 export default useServerStore

--- a/frontend/src/styles/index.css
+++ b/frontend/src/styles/index.css
@@ -123,7 +123,7 @@ em-emoji-picker {
 /* ── Server list column ───────────────────────────────────────────────────── */
 
 .server-list {
-  width: 64px;
+  width: 80px;
   min-height: 100vh;
   background: var(--bg-secondary);
   display: flex;
@@ -136,21 +136,21 @@ em-emoji-picker {
 }
 
 .server-list__divider {
-  width: 32px;
+  width: 48px;
   height: 1px;
   background: var(--border);
   margin: 0.25rem 0;
 }
 
 .server-icon {
-  width: 48px;
-  height: 48px;
-  border-radius: 50%;
+  width: 72px;
+  height: 72px;
+  border-radius: 22%;
   border: 2px solid transparent;
   background: rgba(0, 206, 209, 0.08);
   color: var(--text-primary);
   font-family: var(--font-mono, 'IBM Plex Mono', monospace);
-  font-size: 0.75rem;
+  font-size: 1.1rem;
   cursor: pointer;
   transition: border-color 0.15s, border-radius 0.15s;
   overflow: hidden;
@@ -167,7 +167,7 @@ em-emoji-picker {
 
 .server-icon--active {
   border-color: var(--accent-teal);
-  border-radius: 30%;
+  border-radius: 28%;
 }
 
 .server-icon img {
@@ -180,7 +180,7 @@ em-emoji-picker {
   color: var(--accent-teal);
   font-weight: bold;
   letter-spacing: 0.05em;
-  font-size: 0.8rem;
+  font-size: 1.2rem;
   pointer-events: none;
 }
 
@@ -199,7 +199,7 @@ em-emoji-picker {
 /* Dropdown menu for Add Server button */
 .server-add-menu {
   position: absolute;
-  left: 72px;
+  left: 88px;
   background: var(--bg-secondary);
   border: 1px solid var(--border);
   border-radius: 4px;


### PR DESCRIPTION
Closes #56 — server icons scaled to 72px (1.5x), server-list column widened to 80px, icons render as rounded square instead of circle Closes #42  — sidebar channel section label now shows active server name instead of hardcoded "channels" Closes #59 — delete channel option added under Server Settings → Channels tab (admin/owner only) with confirmation dialog Closes #44 — Server Settings → Members tab: role management (promote/demote), kick members, transfer ownership (owner only); Danger Zone with delete-server confirmation

