### PR TITLE
Feat/per server voice

### DIFF
--- a/backend/app/api/channels.py
+++ b/backend/app/api/channels.py
@@ -476,17 +476,20 @@ async def send_message(
             "tag": tag,
             "is_mention": is_mention,
         }
+        # Always attempt push — the tag field deduplicates on the browser side if
+        # both push and the global-WS notification arrive while the tab is active.
+        # Without this, users whose tab is backgrounded/sleeping miss notifications
+        # because is_globally_connected() stays True while JS is suspended.
+        send_push_to_user(
+            user_id=member.id,
+            title=title,
+            body=body,
+            url=f"/?channel={channel_id}",
+            tag=tag,
+            db=db,
+        )
         if manager.is_globally_connected(member.id):
             global_notifications.append((member.id, payload))
-        else:
-            send_push_to_user(
-                user_id=member.id,
-                title=title,
-                body=body,
-                url=f"/?channel={channel_id}",
-                tag=tag,
-                db=db,
-            )
 
     if global_notifications:
 

--- a/backend/app/api/dms.py
+++ b/backend/app/api/dms.py
@@ -169,16 +169,16 @@ async def send_dm_message(
             "body": (message_in.content or "")[:100],
             "is_mention": True,
         }
+        # Always attempt push — tag deduplicates on the browser side.
+        send_push_to_user(
+            user_id=other_user_id,
+            title=notif_title,
+            body=(message_in.content or "")[:100],
+            url="/",
+            tag=f"dm-{msg.id}",
+            db=db,
+        )
         if manager.is_globally_connected(other_user_id):
             asyncio.ensure_future(manager.send_global_notification(other_user_id, dm_payload))
-        else:
-            send_push_to_user(
-                user_id=other_user_id,
-                title=notif_title,
-                body=(message_in.content or "")[:100],
-                url="/",
-                tag=f"dm-{msg.id}",
-                db=db,
-            )
 
     return response

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -138,9 +138,9 @@ async def dm_websocket_endpoint(websocket: WebSocket, dm_id: int, db: Session = 
     await dm_ws_handler(websocket, dm_id, db)
 
 
-@app.websocket("/ws/voice")
-async def voice_websocket_endpoint(websocket: WebSocket, db: Session = Depends(get_db)) -> None:
-    await voice_ws_handler(websocket, db)
+@app.websocket("/ws/voice/{server_id}")
+async def voice_websocket_endpoint(websocket: WebSocket, server_id: int, db: Session = Depends(get_db)) -> None:
+    await voice_ws_handler(websocket, server_id, db)
 
 
 @app.websocket("/ws/global")

--- a/backend/app/tests/conftest.py
+++ b/backend/app/tests/conftest.py
@@ -61,8 +61,9 @@ def reset_voice_manager():
     voice state (users, pending leave tasks) leaks between tests because the
     grace-period tasks are never awaited in synchronous TestClient tests.
     """
-    for task in list(voice_manager._pending_leaves.values()):
-        task.cancel()
+    for server_tasks in list(voice_manager._pending_leaves.values()):
+        for task in list(server_tasks.values()):
+            task.cancel()
     voice_manager._connections.clear()
     voice_manager._voice_users.clear()
     voice_manager._pending_leaves.clear()

--- a/backend/app/tests/test_voice_ws.py
+++ b/backend/app/tests/test_voice_ws.py
@@ -1,14 +1,15 @@
 """
 WebSocket voice signaling tests.
 
-Covers the /ws/voice endpoint (global, server-wide voice channel):
-  - voice.join broadcasts voice.user_joined to all connected clients
+Covers the /ws/voice/{server_id} endpoint (per-server voice channel):
+  - voice.join broadcasts voice.user_joined to all connected clients in the same server
   - voice.leave broadcasts voice.user_left
   - voice.offer / voice.answer / voice.ice_candidate relayed to target user
-  - Auto-leave on disconnect broadcasts voice.user_left (no channel events)
+  - Auto-leave on disconnect broadcasts voice.user_reconnecting (7-second grace period)
   - Signaling to non-voice target is silently dropped
   - Signaling with non-integer target_id is silently dropped
   - voice.state_snapshot always sent on connect (empty list when voice is empty)
+  - Non-member connection is rejected with close code 4003
 """
 
 from fastapi.testclient import TestClient
@@ -26,10 +27,23 @@ def _register(client: TestClient, username: str, email: str, password: str = "Pa
     return resp.json()  # {"access_token": ..., "user": {...}}
 
 
+def _get_server_id(client: TestClient, token: str) -> int:
+    """Return the ID of the first server the authenticated user belongs to.
+
+    All registered users are auto-joined to the same default server, so fetching
+    the server_id once from any user's token is sufficient per test.
+    """
+    resp = client.get("/api/servers", headers={"Authorization": f"Bearer {token}"})
+    assert resp.status_code == 200, resp.json()
+    servers = resp.json()
+    assert len(servers) > 0, "User belongs to no servers"
+    return servers[0]["id"]
+
+
 def _auth_voice_ws(ws, token: str) -> dict:
     """Send auth and receive the immediate voice.state_snapshot response.
 
-    The /ws/voice endpoint always sends a snapshot right after auth,
+    The /ws/voice/{server_id} endpoint always sends a snapshot right after auth,
     even when no users are in voice (users list will be []).
     """
     ws.send_json({"type": "auth", "token": token})
@@ -48,11 +62,12 @@ class TestVoiceJoinLeave:
         """voice.join from user1 → voice.user_joined broadcast received by user2."""
         d1 = _register(client, "vj1a", "vj1a@x.com")
         d2 = _register(client, "vj1b", "vj1b@x.com")
+        server_id = _get_server_id(client, d1["access_token"])
 
-        with client.websocket_connect("/ws/voice") as ws1:
+        with client.websocket_connect(f"/ws/voice/{server_id}") as ws1:
             _auth_voice_ws(ws1, d1["access_token"])
 
-            with client.websocket_connect("/ws/voice") as ws2:
+            with client.websocket_connect(f"/ws/voice/{server_id}") as ws2:
                 _auth_voice_ws(ws2, d2["access_token"])
 
                 ws1.send_json({"type": "voice.join", "muted": False, "video": False})
@@ -68,11 +83,12 @@ class TestVoiceJoinLeave:
         """voice.leave from user1 → voice.user_left broadcast received by user2."""
         d1 = _register(client, "vl1a", "vl1a@x.com")
         d2 = _register(client, "vl1b", "vl1b@x.com")
+        server_id = _get_server_id(client, d1["access_token"])
 
-        with client.websocket_connect("/ws/voice") as ws1:
+        with client.websocket_connect(f"/ws/voice/{server_id}") as ws1:
             _auth_voice_ws(ws1, d1["access_token"])
 
-            with client.websocket_connect("/ws/voice") as ws2:
+            with client.websocket_connect(f"/ws/voice/{server_id}") as ws2:
                 _auth_voice_ws(ws2, d2["access_token"])
 
                 ws1.send_json({"type": "voice.join", "muted": True, "video": False})
@@ -88,17 +104,18 @@ class TestVoiceJoinLeave:
     def test_voice_disconnect_auto_leave(self, client: TestClient):
         """Closing WS while in voice → voice.user_reconnecting broadcast with 7-second grace.
 
-        Unlike the channel WS, /ws/voice disconnect starts a grace period before
+        Unlike a clean voice.leave, WS disconnect starts a grace period before
         the user is fully evicted. The immediate event is voice.user_reconnecting;
         voice.user_left fires after the delay (not tested here — 7 s is too long).
         """
         d1 = _register(client, "vd1a", "vd1a@x.com")
         d2 = _register(client, "vd1b", "vd1b@x.com")
+        server_id = _get_server_id(client, d1["access_token"])
 
-        with client.websocket_connect("/ws/voice") as ws2:
+        with client.websocket_connect(f"/ws/voice/{server_id}") as ws2:
             _auth_voice_ws(ws2, d2["access_token"])
 
-            with client.websocket_connect("/ws/voice") as ws1:
+            with client.websocket_connect(f"/ws/voice/{server_id}") as ws1:
                 _auth_voice_ws(ws1, d1["access_token"])
 
                 ws1.send_json({"type": "voice.join", "muted": False, "video": False})
@@ -127,11 +144,12 @@ class TestVoiceSignalingRelay:
     def test_voice_offer_relayed_to_target(self, client: TestClient):
         """voice.offer from user1 targeting user2 is delivered to user2."""
         d1, d2 = self._two_users(client, "offer")
+        server_id = _get_server_id(client, d1["access_token"])
 
-        with client.websocket_connect("/ws/voice") as ws1:
+        with client.websocket_connect(f"/ws/voice/{server_id}") as ws1:
             _auth_voice_ws(ws1, d1["access_token"])
 
-            with client.websocket_connect("/ws/voice") as ws2:
+            with client.websocket_connect(f"/ws/voice/{server_id}") as ws2:
                 _auth_voice_ws(ws2, d2["access_token"])
 
                 # Both join voice
@@ -160,11 +178,12 @@ class TestVoiceSignalingRelay:
     def test_voice_answer_relayed_to_target(self, client: TestClient):
         """voice.answer from user2 targeting user1 is delivered to user1."""
         d1, d2 = self._two_users(client, "answer")
+        server_id = _get_server_id(client, d1["access_token"])
 
-        with client.websocket_connect("/ws/voice") as ws1:
+        with client.websocket_connect(f"/ws/voice/{server_id}") as ws1:
             _auth_voice_ws(ws1, d1["access_token"])
 
-            with client.websocket_connect("/ws/voice") as ws2:
+            with client.websocket_connect(f"/ws/voice/{server_id}") as ws2:
                 _auth_voice_ws(ws2, d2["access_token"])
 
                 ws1.send_json({"type": "voice.join", "muted": False, "video": False})
@@ -190,11 +209,12 @@ class TestVoiceSignalingRelay:
     def test_voice_ice_candidate_relayed_to_target(self, client: TestClient):
         """voice.ice_candidate from user1 targeting user2 is delivered to user2."""
         d1, d2 = self._two_users(client, "ice")
+        server_id = _get_server_id(client, d1["access_token"])
 
-        with client.websocket_connect("/ws/voice") as ws1:
+        with client.websocket_connect(f"/ws/voice/{server_id}") as ws1:
             _auth_voice_ws(ws1, d1["access_token"])
 
-            with client.websocket_connect("/ws/voice") as ws2:
+            with client.websocket_connect(f"/ws/voice/{server_id}") as ws2:
                 _auth_voice_ws(ws2, d2["access_token"])
 
                 ws1.send_json({"type": "voice.join", "muted": False, "video": False})
@@ -225,11 +245,12 @@ class TestVoiceSignalingRelay:
         ws2's next message must be voice.user_left, not voice.offer.
         """
         d1, d2 = self._two_users(client, "drop")
+        server_id = _get_server_id(client, d1["access_token"])
 
-        with client.websocket_connect("/ws/voice") as ws1:
+        with client.websocket_connect(f"/ws/voice/{server_id}") as ws1:
             _auth_voice_ws(ws1, d1["access_token"])
 
-            with client.websocket_connect("/ws/voice") as ws2:
+            with client.websocket_connect(f"/ws/voice/{server_id}") as ws2:
                 _auth_voice_ws(ws2, d2["access_token"])
 
                 # Only ws1 joins voice; ws2 does NOT join
@@ -261,14 +282,15 @@ class TestVoiceSignalingRelay:
         dA = _register(client, "isol_a", "isol_a@x.com")
         dB = _register(client, "isol_b", "isol_b@x.com")
         dC = _register(client, "isol_c", "isol_c@x.com")
+        server_id = _get_server_id(client, dA["access_token"])
 
-        with client.websocket_connect("/ws/voice") as wsA:
+        with client.websocket_connect(f"/ws/voice/{server_id}") as wsA:
             _auth_voice_ws(wsA, dA["access_token"])
 
-            with client.websocket_connect("/ws/voice") as wsB:
+            with client.websocket_connect(f"/ws/voice/{server_id}") as wsB:
                 _auth_voice_ws(wsB, dB["access_token"])
 
-                with client.websocket_connect("/ws/voice") as wsC:
+                with client.websocket_connect(f"/ws/voice/{server_id}") as wsC:
                     _auth_voice_ws(wsC, dC["access_token"])
 
                     # All three join voice
@@ -311,11 +333,12 @@ class TestVoiceSignalingRelay:
     def test_offer_with_string_target_id_is_dropped(self, client: TestClient):
         """voice.offer with a non-integer target_user_id is silently dropped."""
         d1, d2 = self._two_users(client, "strid")
+        server_id = _get_server_id(client, d1["access_token"])
 
-        with client.websocket_connect("/ws/voice") as ws1:
+        with client.websocket_connect(f"/ws/voice/{server_id}") as ws1:
             _auth_voice_ws(ws1, d1["access_token"])
 
-            with client.websocket_connect("/ws/voice") as ws2:
+            with client.websocket_connect(f"/ws/voice/{server_id}") as ws2:
                 _auth_voice_ws(ws2, d2["access_token"])
 
                 ws1.send_json({"type": "voice.join", "muted": False, "video": False})
@@ -348,25 +371,27 @@ class TestVoiceSignalingRelay:
 
 class TestVoiceStateSnapshot:
     def test_snapshot_sent_when_voice_occupied(self, client: TestClient):
-        """New /ws/voice connection receives voice.state_snapshot with current participants."""
+        """New /ws/voice/{server_id} connection receives voice.state_snapshot with current participants."""
         d1 = _register(client, "snap1a", "snap1a@x.com")
         d2 = _register(client, "snap1b", "snap1b@x.com")
+        server_id = _get_server_id(client, d1["access_token"])
 
-        with client.websocket_connect("/ws/voice") as ws1:
+        with client.websocket_connect(f"/ws/voice/{server_id}") as ws1:
             _auth_voice_ws(ws1, d1["access_token"])
             ws1.send_json({"type": "voice.join", "muted": True, "video": False})
             ws1.receive_json()  # own voice.user_joined broadcast
 
-            with client.websocket_connect("/ws/voice") as ws2:
+            with client.websocket_connect(f"/ws/voice/{server_id}") as ws2:
                 # Snapshot is the first message after auth — should include d1
                 snapshot = _auth_voice_ws(ws2, d2["access_token"])
                 user_ids = [u["user_id"] for u in snapshot["users"]]
                 assert d1["user"]["id"] in user_ids
 
     def test_snapshot_sent_even_when_voice_empty(self, client: TestClient):
-        """New /ws/voice connection receives voice.state_snapshot with users=[] when empty."""
+        """New /ws/voice/{server_id} connection receives voice.state_snapshot with users=[] when empty."""
         d1 = _register(client, "snap2a", "snap2a@x.com")
+        server_id = _get_server_id(client, d1["access_token"])
 
-        with client.websocket_connect("/ws/voice") as ws1:
+        with client.websocket_connect(f"/ws/voice/{server_id}") as ws1:
             snapshot = _auth_voice_ws(ws1, d1["access_token"])
             assert snapshot["users"] == []

--- a/backend/app/websocket/voice_handler.py
+++ b/backend/app/websocket/voice_handler.py
@@ -1,9 +1,11 @@
-"""Global voice channel WebSocket handler.
+"""Per-server voice channel WebSocket handler.
 
-A single /ws/voice endpoint serves the entire server — voice state is
-not tied to any text channel.  All connected clients receive all voice
-events, and P2P signaling (offer/answer/ICE) is relayed directly between
-voice participants without knowing which text channel they are viewing.
+Each server has its own isolated voice channel.  Users in Server A's voice
+call cannot see or signal users in Server B's voice call.
+
+The endpoint is /ws/voice/{server_id} — the server_id is taken from the URL
+path and validated against the user's server membership before the connection
+is accepted.
 
 NOTE: VoiceConnectionManager is an in-memory singleton, matching the same
 design as ConnectionManager in manager.py.  Both assume a single-process
@@ -19,49 +21,51 @@ from fastapi import WebSocket, WebSocketDisconnect
 from sqlalchemy.orm import Session
 
 from app.core import events
-from app.websocket.handlers import _authenticate
+from app.models.server_membership import ServerMembership
+from app.websocket.handlers import _authenticate, _ws_close
 
 logger = logging.getLogger(__name__)
 
-# channel_id value included in voice protocol messages.
-# 0 signals "global / server-wide" — there is no corresponding DB row.
-GLOBAL_VOICE_CHANNEL = 0
-
 
 class VoiceConnectionManager:
-    """Tracks voice WebSocket connections and voice user state globally."""
+    """Tracks voice WebSocket connections and voice user state, scoped per server."""
 
     def __init__(self) -> None:
-        # user_id -> WebSocket
-        self._connections: dict[int, WebSocket] = {}
-        # user_id -> {user_id, username, muted, video, speaking}
-        self._voice_users: dict[int, dict] = {}
-        # user_id -> pending leave task (7-second grace period)
-        self._pending_leaves: dict[int, asyncio.Task] = {}
+        # server_id -> {user_id -> WebSocket}
+        self._connections: dict[int, dict[int, WebSocket]] = {}
+        # server_id -> {user_id -> {user_id, username, muted, video, speaking}}
+        self._voice_users: dict[int, dict[int, dict]] = {}
+        # server_id -> {user_id -> pending leave task (7-second grace period)}
+        self._pending_leaves: dict[int, dict[int, asyncio.Task]] = {}
 
     # ------------------------------------------------------------------
     # Connection management
     # ------------------------------------------------------------------
 
-    async def connect(self, user_id: int, websocket: WebSocket) -> None:
-        # Close any stale connection for this user before replacing it
-        old = self._connections.get(user_id)
+    async def connect(self, server_id: int, user_id: int, websocket: WebSocket) -> None:
+        server_conns = self._connections.setdefault(server_id, {})
+        # Close any stale connection for this user in this server before replacing it
+        old = server_conns.get(user_id)
         if old is not None:
             try:
                 await old.close()
             except Exception:
                 pass
-        self._connections[user_id] = websocket
+        server_conns[user_id] = websocket
 
-    def disconnect(self, user_id: int) -> None:
-        self._connections.pop(user_id, None)
+    def disconnect(self, server_id: int, user_id: int) -> None:
+        server_conns = self._connections.get(server_id)
+        if server_conns is not None:
+            server_conns.pop(user_id, None)
+            if not server_conns:
+                self._connections.pop(server_id, None)
 
     # ------------------------------------------------------------------
     # Voice state
     # ------------------------------------------------------------------
 
-    def join_voice(self, user_id: int, username: str, muted: bool, video: bool) -> None:
-        self._voice_users[user_id] = {
+    def join_voice(self, server_id: int, user_id: int, username: str, muted: bool, video: bool) -> None:
+        self._voice_users.setdefault(server_id, {})[user_id] = {
             "user_id": user_id,
             "username": username,
             "muted": muted,
@@ -69,49 +73,57 @@ class VoiceConnectionManager:
             "speaking": False,
         }
 
-    def leave_voice(self, user_id: int) -> bool:
-        return self._voice_users.pop(user_id, None) is not None
+    def leave_voice(self, server_id: int, user_id: int) -> bool:
+        server_voice = self._voice_users.get(server_id)
+        if server_voice is None:
+            return False
+        existed = server_voice.pop(user_id, None) is not None
+        if not server_voice:
+            self._voice_users.pop(server_id, None)
+        return existed
 
-    def update_voice(self, user_id: int, muted: bool, video: bool, speaking: bool) -> None:
-        state = self._voice_users.get(user_id)
+    def update_voice(self, server_id: int, user_id: int, muted: bool, video: bool, speaking: bool) -> None:
+        state = self._voice_users.get(server_id, {}).get(user_id)
         if state:
             state["muted"] = muted
             state["video"] = video
             state["speaking"] = speaking
 
-    def is_in_voice(self, user_id: int) -> bool:
-        return user_id in self._voice_users
+    def is_in_voice(self, server_id: int, user_id: int) -> bool:
+        return user_id in self._voice_users.get(server_id, {})
 
-    def get_snapshot(self) -> list[dict]:
-        return list(self._voice_users.values())
+    def get_snapshot(self, server_id: int) -> list[dict]:
+        return list(self._voice_users.get(server_id, {}).values())
 
     # ------------------------------------------------------------------
     # Reconnection grace period
     # ------------------------------------------------------------------
 
-    async def schedule_leave(self, user_id: int, delay: float = 7.0) -> None:
+    async def schedule_leave(self, server_id: int, user_id: int, delay: float = 7.0) -> None:
         """Broadcast user_left after `delay` seconds unless cancel_leave() is called first."""
-        existing = self._pending_leaves.pop(user_id, None)
+        server_leaves = self._pending_leaves.setdefault(server_id, {})
+        existing = server_leaves.pop(user_id, None)
         if existing:
             existing.cancel()
 
         async def _delayed() -> None:
             await asyncio.sleep(delay)
-            if self.leave_voice(user_id):
+            if self.leave_voice(server_id, user_id):
                 await self.broadcast(
+                    server_id,
                     {
                         "type": events.VOICE_USER_LEFT,
-                        "channel_id": GLOBAL_VOICE_CHANNEL,
+                        "channel_id": server_id,
                         "user_id": user_id,
-                    }
+                    },
                 )
-            self._pending_leaves.pop(user_id, None)
+            self._pending_leaves.get(server_id, {}).pop(user_id, None)
 
-        self._pending_leaves[user_id] = asyncio.create_task(_delayed())
+        server_leaves[user_id] = asyncio.create_task(_delayed())
 
-    def cancel_leave(self, user_id: int) -> None:
+    def cancel_leave(self, server_id: int, user_id: int) -> None:
         """Cancel a pending delayed leave (user reconnected in time)."""
-        task = self._pending_leaves.pop(user_id, None)
+        task = self._pending_leaves.get(server_id, {}).pop(user_id, None)
         if task:
             task.cancel()
 
@@ -119,11 +131,11 @@ class VoiceConnectionManager:
     # Messaging
     # ------------------------------------------------------------------
 
-    async def broadcast(self, payload: dict, exclude: int | None = None) -> None:
-        """Send to all connected voice WS clients."""
+    async def broadcast(self, server_id: int, payload: dict, exclude: int | None = None) -> None:
+        """Send to all voice WS clients connected to this server."""
         data = json.dumps(payload)
         dead: list[int] = []
-        for uid, ws in list(self._connections.items()):
+        for uid, ws in list(self._connections.get(server_id, {}).items()):
             if uid == exclude:
                 continue
             try:
@@ -131,33 +143,46 @@ class VoiceConnectionManager:
             except Exception:
                 dead.append(uid)
         for uid in dead:
-            self.disconnect(uid)
+            self.disconnect(server_id, uid)
 
-    async def send_to(self, user_id: int, payload: dict) -> None:
-        """Send to a specific connected user."""
-        ws = self._connections.get(user_id)
+    async def send_to(self, server_id: int, user_id: int, payload: dict) -> None:
+        """Send to a specific connected user within a server."""
+        ws = self._connections.get(server_id, {}).get(user_id)
         if ws is None:
             return
         try:
             await ws.send_text(json.dumps(payload))
         except Exception:
-            self.disconnect(user_id)
+            self.disconnect(server_id, user_id)
 
 
 # Module-level singleton — shared across all connections (single-process only)
 voice_manager = VoiceConnectionManager()
 
 
-async def voice_ws_handler(websocket: WebSocket, db: Session) -> None:
-    """Full lifecycle handler for the global /ws/voice endpoint."""
+async def voice_ws_handler(websocket: WebSocket, server_id: int, db: Session) -> None:
+    """Full lifecycle handler for the per-server /ws/voice/{server_id} endpoint."""
     # Reuse the shared auth helper (accepts + verifies the JWT handshake)
     user = await _authenticate(websocket, db)
     if user is None:
         return
 
-    await voice_manager.connect(user.id, websocket)
+    # Verify the user is a member of this server before accepting voice connection
+    membership = (
+        db.query(ServerMembership)
+        .filter(
+            ServerMembership.server_id == server_id,
+            ServerMembership.user_id == user.id,
+        )
+        .first()
+    )
+    if not membership:
+        await _ws_close(websocket, code=4003)
+        return
+
+    await voice_manager.connect(server_id, user.id, websocket)
     # Cancel any pending grace-period leave from a previous disconnect
-    voice_manager.cancel_leave(user.id)
+    voice_manager.cancel_leave(server_id, user.id)
 
     # Send the current participant list to the newly connected client so it
     # can clear any stale state from a previous session.
@@ -165,8 +190,8 @@ async def voice_ws_handler(websocket: WebSocket, db: Session) -> None:
         json.dumps(
             {
                 "type": events.VOICE_STATE_SNAPSHOT,
-                "channel_id": GLOBAL_VOICE_CHANNEL,
-                "users": voice_manager.get_snapshot(),
+                "channel_id": server_id,
+                "users": voice_manager.get_snapshot(server_id),
             }
         )
     )
@@ -186,37 +211,40 @@ async def voice_ws_handler(websocket: WebSocket, db: Session) -> None:
                 if msg_type == events.VOICE_JOIN:
                     muted = bool(msg.get("muted", True))
                     video = bool(msg.get("video", False))
-                    voice_manager.join_voice(user.id, user.username, muted, video)
+                    voice_manager.join_voice(server_id, user.id, user.username, muted, video)
                     await voice_manager.broadcast(
+                        server_id,
                         {
                             "type": events.VOICE_USER_JOINED,
-                            "channel_id": GLOBAL_VOICE_CHANNEL,
+                            "channel_id": server_id,
                             "user_id": user.id,
                             "username": user.username,
                             "muted": muted,
                             "video": video,
-                        }
+                        },
                     )
 
                 elif msg_type == events.VOICE_LEAVE:
-                    voice_manager.leave_voice(user.id)
+                    voice_manager.leave_voice(server_id, user.id)
                     await voice_manager.broadcast(
+                        server_id,
                         {
                             "type": events.VOICE_USER_LEFT,
-                            "channel_id": GLOBAL_VOICE_CHANNEL,
+                            "channel_id": server_id,
                             "user_id": user.id,
-                        }
+                        },
                     )
 
                 elif msg_type == events.VOICE_STATE_UPDATE:
                     muted = bool(msg.get("muted", True))
                     video = bool(msg.get("video", False))
                     speaking = bool(msg.get("speaking", False))
-                    voice_manager.update_voice(user.id, muted, video, speaking)
+                    voice_manager.update_voice(server_id, user.id, muted, video, speaking)
                     await voice_manager.broadcast(
+                        server_id,
                         {
                             "type": events.VOICE_STATE_CHANGED,
-                            "channel_id": GLOBAL_VOICE_CHANNEL,
+                            "channel_id": server_id,
                             "user_id": user.id,
                             "muted": muted,
                             "video": video,
@@ -229,9 +257,10 @@ async def voice_ws_handler(websocket: WebSocket, db: Session) -> None:
                     target_id = msg.get("target_user_id")
                     if not isinstance(target_id, int):
                         continue
-                    if not voice_manager.is_in_voice(target_id):
+                    if not voice_manager.is_in_voice(server_id, target_id):
                         continue
                     await voice_manager.send_to(
+                        server_id,
                         target_id,
                         {
                             "type": msg_type,
@@ -244,9 +273,10 @@ async def voice_ws_handler(websocket: WebSocket, db: Session) -> None:
                     target_id = msg.get("target_user_id")
                     if not isinstance(target_id, int):
                         continue
-                    if not voice_manager.is_in_voice(target_id):
+                    if not voice_manager.is_in_voice(server_id, target_id):
                         continue
                     await voice_manager.send_to(
+                        server_id,
                         target_id,
                         {
                             "type": msg_type,
@@ -272,16 +302,17 @@ async def voice_ws_handler(websocket: WebSocket, db: Session) -> None:
     except Exception as exc:
         logger.exception("voice_ws_handler: unexpected error: %s", exc)
     finally:
-        was_in_voice = voice_manager.is_in_voice(user.id)
-        voice_manager.disconnect(user.id)
+        was_in_voice = voice_manager.is_in_voice(server_id, user.id)
+        voice_manager.disconnect(server_id, user.id)
         if was_in_voice:
             # Broadcast reconnecting state; schedule actual leave after grace period.
             # If the user reconnects within 7 seconds, cancel_leave() clears the task.
             await voice_manager.broadcast(
+                server_id,
                 {
                     "type": events.VOICE_USER_RECONNECTING,
-                    "channel_id": GLOBAL_VOICE_CHANNEL,
+                    "channel_id": server_id,
                     "user_id": user.id,
-                }
+                },
             )
-            await voice_manager.schedule_leave(user.id, delay=7.0)
+            await voice_manager.schedule_leave(server_id, user.id, delay=7.0)

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -37,7 +37,8 @@ function ChatLayout() {
   const [sidebarOpen, setSidebarOpen] = useState(true)
   const [bookmarksOpen, setBookmarksOpen] = useState(false)
 
-  const { sendVoiceMsg, voiceConnected } = useVoiceWebSocket(token)
+  const activeServerId = useServerStore((s) => s.activeServerId)
+  const { sendVoiceMsg, voiceConnected } = useVoiceWebSocket(token, activeServerId)
   useGlobalWebSocket(token)
   const invite = useInviteModal()
 

--- a/frontend/src/components/Voice/VoiceControls.jsx
+++ b/frontend/src/components/Voice/VoiceControls.jsx
@@ -6,7 +6,9 @@
  *   currentUser — { id, username } from authStore
  *   sendMsg     — sendMsg() from useWebSocket
  */
+import { useRef, useEffect } from 'react'
 import useChatStore from '../../store/chatStore'
+import useServerStore from '../../store/serverStore'
 import { useVoiceChat } from '../../hooks/useVoiceChat'
 import VoiceUser from './VoiceUser'
 
@@ -24,6 +26,16 @@ export default function VoiceControls({ currentUser, sendMsg, connected }) {
     currentUser,
     sendMsg,
   )
+
+  // Auto-leave voice when the user switches servers to avoid stale peer connections
+  const activeServerId = useServerStore((s) => s.activeServerId)
+  const prevServerIdRef = useRef(activeServerId)
+  useEffect(() => {
+    if (prevServerIdRef.current !== activeServerId) {
+      prevServerIdRef.current = activeServerId
+      if (inVoice) leaveVoice()
+    }
+  }, [activeServerId, inVoice, leaveVoice])
 
   const participants = Object.values(voiceUsers)
   const micLabel = micErrorLabel(micError)

--- a/frontend/src/hooks/useVoiceWebSocket.js
+++ b/frontend/src/hooks/useVoiceWebSocket.js
@@ -1,10 +1,10 @@
 /**
- * useVoiceWebSocket — persistent WebSocket connection to /ws/voice.
+ * useVoiceWebSocket — persistent WebSocket connection to /ws/voice/{serverId}.
  *
- * Unlike the channel WebSocket this connection is NOT tied to any text
- * channel.  It stays open for the lifetime of the ChatLayout and
- * survives text-channel switches, so voice state is never interrupted
- * by navigation.
+ * Scoped to the active server — voice participants in Server A are invisible
+ * to users in Server B.  The connection reconnects automatically when the
+ * active server changes, and the incoming voice.state_snapshot clears any
+ * stale voice state from the previous server.
  */
 
 import { useState, useEffect, useRef, useCallback } from 'react'
@@ -16,7 +16,7 @@ function getBackoffDelay(attempt) {
   return Math.min(1000 * Math.pow(2, attempt), 30000)
 }
 
-export function useVoiceWebSocket(token) {
+export function useVoiceWebSocket(token, serverId) {
   const [connected, setConnected] = useState(false)
 
   const wsRef = useRef(null)
@@ -36,9 +36,9 @@ export function useVoiceWebSocket(token) {
   }, [])
 
   const connect = useCallback(() => {
-    if (!token) return
+    if (!token || !serverId) return
     const proto = window.location.protocol === 'https:' ? 'wss' : 'ws'
-    const ws = new WebSocket(`${proto}://${window.location.host}/ws/voice`)
+    const ws = new WebSocket(`${proto}://${window.location.host}/ws/voice/${serverId}`)
     wsRef.current = ws
 
     ws.onopen = () => {
@@ -55,7 +55,7 @@ export function useVoiceWebSocket(token) {
 
       switch (data.type) {
         case 'voice.state_snapshot':
-          // Atomically replace state — clears anyone who left during a disconnect
+          // Atomically replace state — clears stale participants from previous server
           setVoiceSnapshot(data.users)
           break
         case 'voice.user_joined':
@@ -101,7 +101,7 @@ export function useVoiceWebSocket(token) {
     }
 
     ws.onerror = () => ws.close()
-  }, [token, setVoiceSnapshot, setVoiceUser, removeVoiceUser, pushVoiceSignal])
+  }, [token, serverId, setVoiceSnapshot, setVoiceUser, removeVoiceUser, pushVoiceSignal])
 
   useEffect(() => {
     mountedRef.current = true

--- a/frontend/src/hooks/useWebSocket.js
+++ b/frontend/src/hooks/useWebSocket.js
@@ -206,16 +206,6 @@ export function useWebSocket(serverId, token) {
           }
           break
         }
-        case 'notification': {
-          // Cross-server or cross-context notification delivered via this WS connection.
-          if (!isInQuietHours(useAuthStore.getState().quietHours)) {
-            showNotification(data.title, {
-              body: data.body,
-              tag: data.tag,
-            })
-          }
-          break
-        }
         case 'nickname_changed': {
           useChatStore.getState().updateUserDisplayName(data.user_id, data.display_name)
           break


### PR DESCRIPTION
Root cause and fix summary:

What regressed: v0.9.0 introduced the global WebSocket notification path with an either/or guard — if the user's global WS was connected, push was skipped and the notification was sent via WebSocket instead. This looks correct on paper but fails in practice because:

is_globally_connected() returns True as long as the WebSocket object hasn't been closed — but mobile browsers and background desktop tabs suspend the JavaScript event loop
The WS message arrives at the socket buffer, but onmessage never fires because JS is frozen
Result: the user misses the notification entirely; push would have worked because it's delivered at the OS level via the browser's push server
What was changed:

[channels.py](vscode-webview://0jori7loi404dr82mpl8uoj4gco3g4523u715ia6em49knlai6rm/backend/app/api/channels.py) — send_push_to_user() now always fires first, then the WS notification is queued separately if the user is globally connected. The notification tag field deduplicates on the browser side — if both arrive while the tab is active, the push silently replaces the WS notification (renotify: false). No double alert.
[dms.py](vscode-webview://0jori7loi404dr82mpl8uoj4gco3g4523u715ia6em49knlai6rm/backend/app/api/dms.py) — same change for DM notifications
[useWebSocket.js](vscode-webview://0jori7loi404dr82mpl8uoj4gco3g4523u715ia6em49knlai6rm/frontend/src/hooks/useWebSocket.js) — removed a duplicate case 'notification': block that was unreachable dead code (the first occurrence at line 188 always matched first)